### PR TITLE
don't crash for not animated webp images

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,36 +149,36 @@ fn make_request(args: &Swww) -> Result<Option<Request>, String> {
             let requested_outputs = split_cmdline_outputs(&img.outputs);
             let (dims, outputs) = get_dimensions_and_outputs(&requested_outputs)?;
             let imgbuf = ImgBuf::new(&img.path)?;
-            if imgbuf.is_animated() {
-                match std::thread::scope::<_, Result<_, String>>(|s1| {
-                    let animations = s1.spawn(|| make_animation_request(img, &dims, &outputs));
-                    let first_frame = imgbuf
-                        .into_frames()?
-                        .next()
-                        .ok_or("missing first frame".to_owned())?
-                        .map_err(|e| format!("unable to decode first frame: {e}"))?;
+            match imgbuf.get_animation_frames(&img.path)? {
+                MaybeFrames::Animated(mut frames) => {
+                    match std::thread::scope::<_, Result<_, String>>(|s1| {
+                        let animations = s1.spawn(|| make_animation_request(img, &dims, &outputs));
+                        let first_frame = frames
+                            .next()
+                            .ok_or("missing first frame".to_owned())?
+                            .map_err(|e| format!("unable to decode first frame: {e}"))?;
 
-                    let img_request =
-                        make_img_request(img, frame_to_rgb(first_frame), &dims, &outputs)?;
-                    let animations = animations.join().unwrap_or_else(|e| Err(format!("{e:?}")));
+                        let img_request =
+                            make_img_request(img, frame_to_rgb(first_frame), &dims, &outputs)?;
+                        let animations =
+                            animations.join().unwrap_or_else(|e| Err(format!("{e:?}")));
 
-                    let socket = connect_to_socket(5, 100)?;
-                    Request::Img(img_request).send(&socket)?;
-                    let bytes = read_socket(&socket)?;
-                    drop(socket);
-                    if let ArchivedAnswer::Err(e) = Answer::receive(&bytes) {
-                        return Err(format!("daemon error when sending image: {e}"));
+                        let socket = connect_to_socket(5, 100)?;
+                        Request::Img(img_request).send(&socket)?;
+                        let bytes = read_socket(&socket)?;
+                        drop(socket);
+                        if let ArchivedAnswer::Err(e) = Answer::receive(&bytes) {
+                            return Err(format!("daemon error when sending image: {e}"));
+                        }
+                        animations
+                    }) {
+                        Ok(animations) => Ok(Some(Request::Animation(animations))),
+                        Err(e) => Err(format!("failed to create animated request: {e}")),
                     }
-                    animations
-                }) {
-                    Ok(animations) => Ok(Some(Request::Animation(animations))),
-                    Err(e) => Err(format!("failed to create animated request: {e}")),
                 }
-            } else {
-                let img_raw = imgbuf.decode()?;
-                Ok(Some(Request::Img(make_img_request(
+                MaybeFrames::NotAnimated(img_raw) => Ok(Some(Request::Img(make_img_request(
                     img, img_raw, &dims, &outputs,
-                )?)))
+                )?))),
             }
         }
         Swww::Init { .. } => Ok(Some(Request::Init)),


### PR DESCRIPTION
This patch checks that if the webp image is animated and if not, it will create a single static image.
Note that currently the image file will be read twice. This is unfortunate but I wasn't able to find a better way to do it.

Fixes: #201