### PR TITLE
New compression functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,12 +643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "lebe"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,7 +1408,6 @@ name = "utils"
 version = "0.8.2-master"
 dependencies = [
  "criterion",
- "lazy_static",
  "lzzzz",
  "rand",
  "rkyv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,6 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -606,15 +605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "jobserver"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "jpeg-decoder"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,15 +681,6 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-
-[[package]]
-name = "lzzzz"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8014d1362004776e6a91e4c15a3aa7830d1b6650a075b51a9969ebb6d6af13bc"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "memchr"
@@ -1408,7 +1389,7 @@ name = "utils"
 version = "0.8.2-master"
 dependencies = [
  "criterion",
- "lzzzz",
+ "pkg-config",
  "rand",
  "rkyv",
 ]

--- a/daemon/src/animations/mod.rs
+++ b/daemon/src/animations/mod.rs
@@ -134,7 +134,7 @@ impl Animator {
 
                 let mut now = std::time::Instant::now();
 
-                let decompressor = Decompressor::new();
+                let mut decompressor = Decompressor::new();
                 for (frame, duration) in animation.animation.iter().cycle() {
                     let duration: Duration = duration.deserialize(&mut rkyv::Infallible).unwrap();
                     barrier.wait(duration.div_f32(2.0));

--- a/daemon/src/animations/mod.rs
+++ b/daemon/src/animations/mod.rs
@@ -109,7 +109,7 @@ impl Animator {
             .stack_size(STACK_SIZE) //the default of 2MB is way too overkill for this
             .spawn_scoped(scope, move || {
                 /* We only need to animate if we have > 1 frame */
-                if animation.animation.len() == 1 {
+                if animation.animation.len() <= 1 {
                     return;
                 }
                 log::debug!("Starting animation");
@@ -148,12 +148,12 @@ impl Animator {
                             continue;
                         }
 
-                        let success = wallpapers[i].canvas_change(|canvas| {
+                        let result = wallpapers[i].canvas_change(|canvas| {
                             decompressor.decompress_archived(frame, canvas)
                         });
 
-                        if !success {
-                            error!("failed to unpack frame, canvas is smaller than expected");
+                        if let Err(e) = result {
+                            error!("failed to unpack frame: {e}");
                             wallpapers.swap_remove(i);
                             tokens.swap_remove(i);
                             continue;

--- a/src/imgproc.rs
+++ b/src/imgproc.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use utils::{
-    comp_decomp::{BitPack, Compressor},
+    compression::{BitPack, Compressor},
     ipc::{self, Coord, Position},
 };
 

--- a/src/imgproc.rs
+++ b/src/imgproc.rs
@@ -151,7 +151,7 @@ pub fn compress_frames(
     resize: ResizeStrategy,
     color: &[u8; 3],
 ) -> Result<Vec<(BitPack, Duration)>, String> {
-    let compressor = Compressor::new();
+    let mut compressor = Compressor::new();
     let mut compressed_frames = Vec::new();
 
     // The first frame should always exist

--- a/src/imgproc.rs
+++ b/src/imgproc.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use utils::{
-    comp_decomp::BitPack,
+    comp_decomp::{BitPack, Compressor},
     ipc::{self, Coord, Position},
 };
 
@@ -151,6 +151,7 @@ pub fn compress_frames(
     resize: ResizeStrategy,
     color: &[u8; 3],
 ) -> Result<Vec<(BitPack, Duration)>, String> {
+    let compressor = Compressor::new();
     let mut compressed_frames = Vec::new();
 
     // The first frame should always exist
@@ -175,14 +176,14 @@ pub fn compress_frames(
         };
 
         compressed_frames.push((
-            BitPack::pack(canvas.as_ref().unwrap_or(&first_img), &img)?,
+            compressor.compress(canvas.as_ref().unwrap_or(&first_img), &img)?,
             duration,
         ));
         canvas = Some(img);
     }
     //Add the first frame we got earlier:
     compressed_frames.push((
-        BitPack::pack(canvas.as_ref().unwrap_or(&first_img), &first_img)?,
+        compressor.compress(canvas.as_ref().unwrap_or(&first_img), &first_img)?,
         first_duration,
     ));
     Ok(compressed_frames)

--- a/tests/spell_check.rs
+++ b/tests/spell_check.rs
@@ -11,7 +11,7 @@ fn spell_check_code_and_man_pages() {
         .args([
             "--enable-colors",
             "--ignore-words-list",
-            "crate",
+            "crate,statics",
             "--skip",
             "doc/generated",   // skip the generated documentation
             "src",             // client

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-lazy_static = "1.4"
 lzzzz = "=1.0.4"
 rkyv = "0.7"
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-lzzzz = "=1.0.4"
 rkyv = "0.7"
+
+[build-dependencies]
+pkg-config = "0.3"
 
 [dev-dependencies]
 rand = "0.8"

--- a/utils/benches/compression.rs
+++ b/utils/benches/compression.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use utils::comp_decomp::BitPack;
+use utils::compression::{Compressor, Decompressor};
 
 fn generate_data() -> (Box<[u8]>, Box<[u8]>) {
     let v1 = vec![120; 1920 * 1080 * 3];
@@ -39,22 +39,20 @@ fn buf_from(slice: &[u8]) -> Vec<u8> {
 pub fn compression_and_decompression(c: &mut Criterion) {
     let (prev, cur) = generate_data();
 
+    let compressor = Compressor::new();
     let mut comp = c.benchmark_group("compression");
     comp.bench_function("Full", |b| {
-        b.iter(|| {
-            black_box(BitPack::pack(&prev, &cur).ok());
-        })
+        b.iter(|| black_box(compressor.compress(&prev, &cur).ok()))
     });
     comp.finish();
 
     let mut decomp = c.benchmark_group("decompression");
-    let bitpack = BitPack::pack(&prev, &cur).unwrap();
+    let bitpack = compressor.compress(&prev, &cur).unwrap();
     let mut canvas = buf_from(&prev);
 
+    let decompressor = Decompressor::new();
     decomp.bench_function("Full", |b| {
-        b.iter(|| {
-            black_box(bitpack.unpack(&mut canvas));
-        })
+        b.iter(|| black_box(decompressor.decompress(&bitpack, &mut canvas)))
     });
 
     decomp.finish();

--- a/utils/benches/compression.rs
+++ b/utils/benches/compression.rs
@@ -39,7 +39,7 @@ fn buf_from(slice: &[u8]) -> Vec<u8> {
 pub fn compression_and_decompression(c: &mut Criterion) {
     let (prev, cur) = generate_data();
 
-    let compressor = Compressor::new();
+    let mut compressor = Compressor::new();
     let mut comp = c.benchmark_group("compression");
     comp.bench_function("Full", |b| {
         b.iter(|| black_box(compressor.compress(&prev, &cur).ok()))

--- a/utils/benches/compression.rs
+++ b/utils/benches/compression.rs
@@ -50,7 +50,7 @@ pub fn compression_and_decompression(c: &mut Criterion) {
     let bitpack = compressor.compress(&prev, &cur).unwrap();
     let mut canvas = buf_from(&prev);
 
-    let decompressor = Decompressor::new();
+    let mut decompressor = Decompressor::new();
     decomp.bench_function("Full", |b| {
         b.iter(|| black_box(decompressor.decompress(&bitpack, &mut canvas)))
     });

--- a/utils/benches/compression.rs
+++ b/utils/benches/compression.rs
@@ -42,7 +42,7 @@ pub fn compression_and_decompression(c: &mut Criterion) {
     let mut compressor = Compressor::new();
     let mut comp = c.benchmark_group("compression");
     comp.bench_function("Full", |b| {
-        b.iter(|| black_box(compressor.compress(&prev, &cur).ok()))
+        b.iter(|| black_box(compressor.compress(&prev, &cur).is_some()))
     });
     comp.finish();
 

--- a/utils/build.rs
+++ b/utils/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     pkg_config::Config::new()
-        .atleast_version("1.9")
+        .atleast_version("1.8")
         .probe("liblz4")
         .unwrap();
 }

--- a/utils/build.rs
+++ b/utils/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    pkg_config::Config::new()
+        .atleast_version("1.9")
+        .probe("liblz4")
+        .unwrap();
+}

--- a/utils/src/compression/comp/mod.rs
+++ b/utils/src/compression/comp/mod.rs
@@ -82,7 +82,7 @@ pub(super) fn pack_bytes(cur: &[u8], goal: &[u8], v: &mut Vec<u8>) {
         i += equals * 3;
 
         if i >= cur.len() {
-            return;
+            break;
         }
 
         let start = i;
@@ -97,7 +97,11 @@ pub(super) fn pack_bytes(cur: &[u8], goal: &[u8], v: &mut Vec<u8>) {
         v.extend_from_slice(unsafe { goal.get_unchecked(start..i) });
         i += 3;
     }
-    v.push(0);
+
+    if !v.is_empty() {
+        // add one extra zero to prevent access out of bounds later during decompression
+        v.push(0)
+    }
 }
 
 #[cfg(test)]

--- a/utils/src/compression/comp/mod.rs
+++ b/utils/src/compression/comp/mod.rs
@@ -1,5 +1,134 @@
-//! This modules contains all the specialized compression functions, for each architecture, using
-//! special SIMD functions and instructions
+//! # Compression Strategy
+//!
+//! We only compress RBG images, 8 bytes per channel; I don't think anyone will use
+//! transparency for a background (nor if it even makes sense)
+//!
+//! For what's left, we store only the difference from the last frame to this one.
+//! We do that as follows:
+//! * First, we count how many pixels didn't change. We store that value as a u8.
+//!   Every time the u8 hits the max (i.e. 255, or 0xFF), we push in onto the vector
+//!   and restart the counting.
+//! * Once we find a pixel that has changed, we count, starting from that one, how many
+//!   changed, the same way we counted above (i.e. store as u8, every time it hits the
+//!   max push and restart the counting)
+//! * Then, we store all the new bytes.
+//! * Start from the top until we are done with the image
+//!
+//! The default implementation lies in this file. Architecture-specific implementations
+//! that make use of specialized instructions lie in other submodules.
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(super) mod sse2;
+
+/// SAFETY: s1.len() must be equal to s2.len()
+#[inline(always)]
+pub(super) unsafe fn count_equals(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
+    let mut equals = 0;
+    while i + 7 < s1.len() {
+        let a: u64 = unsafe { s1.as_ptr().add(i).cast::<u64>().read_unaligned() };
+        let b: u64 = unsafe { s2.as_ptr().add(i).cast::<u64>().read_unaligned() };
+        let cmp = a ^ b;
+        if cmp != 0 {
+            equals += cmp.trailing_zeros() as usize / 24;
+            return equals;
+        }
+        equals += 2;
+        i += 6;
+    }
+
+    while i + 2 < s1.len() {
+        let a = unsafe { s1.get_unchecked(i..i + 3) };
+        let b = unsafe { s2.get_unchecked(i..i + 3) };
+        if a != b {
+            break;
+        }
+        equals += 1;
+        i += 3;
+    }
+    equals
+}
+
+/// SAFETY: s1.len() must be equal to s2.len()
+#[inline(always)]
+pub(super) unsafe fn count_different(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
+    let mut different = 0;
+    while i + 2 < s1.len() {
+        let a = unsafe { s1.get_unchecked(i..i + 3) };
+        let b = unsafe { s2.get_unchecked(i..i + 3) };
+        if a == b {
+            break;
+        }
+        different += 1;
+        i += 3;
+    }
+    different
+}
+
+/// This calculates the difference between the current(cur) frame and the next(goal)
+#[inline(always)]
+pub(super) fn pack_bytes(cur: &[u8], goal: &[u8]) -> Box<[u8]> {
+    // use the most efficient implementation available:
+    #[cfg(not(test))] // when testing, we want to use the specific implementation
+    {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if super::cpu::features::sse2() {
+            return unsafe { sse2::pack_bytes(cur, goal) };
+        }
+    }
+
+    let mut v = Vec::with_capacity((goal.len() * 5) / 8);
+
+    let mut i = 0;
+    while i < cur.len() {
+        let equals = unsafe { count_equals(cur, goal, i) };
+        i += equals * 3;
+
+        if i >= cur.len() {
+            return v.into_boxed_slice();
+        }
+
+        let start = i;
+        let diffs = unsafe { count_different(cur, goal, i) };
+        i += diffs * 3;
+
+        let j = v.len() + equals / 255;
+        v.resize(1 + j + diffs / 255, 255);
+        v[j] = (equals % 255) as u8;
+        v.push((diffs % 255) as u8);
+
+        v.extend_from_slice(unsafe { goal.get_unchecked(start..i) });
+        i += 3;
+    }
+    v.push(0);
+    v.into_boxed_slice()
+}
+
+#[cfg(test)]
+mod tests {
+    // note the full compression -> decompression roundtrip is tested in super
+
+    use super::*;
+    #[test]
+    fn count_equal_test() {
+        let a = [0u8; 102];
+        assert_eq!(unsafe { count_equals(&a, &a, 0) }, 102 / 3);
+        for i in [0, 10, 20, 30, 40, 50, 60, 70, 80, 90] {
+            let mut b = a;
+            b[i] = 1;
+            assert_eq!(unsafe { count_equals(&a, &b, 0) }, i / 3, "i: {i}");
+        }
+    }
+
+    #[test]
+    fn count_diffs_test() {
+        let a = [0u8; 102];
+        assert_eq!(unsafe { count_different(&a, &a, 0) }, 0,);
+        for i in [10, 20, 30, 40, 50, 60, 70, 80, 90, 102] {
+            let mut b = a;
+            for x in &mut b[..i] {
+                *x = 1;
+            }
+            assert_eq!(unsafe { count_different(&a, &b, 0) }, (i + 2) / 3, "i: {i}");
+        }
+    }
+}

--- a/utils/src/compression/comp/mod.rs
+++ b/utils/src/compression/comp/mod.rs
@@ -66,17 +66,15 @@ pub(super) unsafe fn count_different(s1: &[u8], s2: &[u8], mut i: usize) -> usiz
 
 /// This calculates the difference between the current(cur) frame and the next(goal)
 #[inline(always)]
-pub(super) fn pack_bytes(cur: &[u8], goal: &[u8]) -> Box<[u8]> {
+pub(super) fn pack_bytes(cur: &[u8], goal: &[u8], v: &mut Vec<u8>) {
     // use the most efficient implementation available:
     #[cfg(not(test))] // when testing, we want to use the specific implementation
     {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         if super::cpu::features::sse2() {
-            return unsafe { sse2::pack_bytes(cur, goal) };
+            return unsafe { sse2::pack_bytes(cur, goal, v) };
         }
     }
-
-    let mut v = Vec::with_capacity((goal.len() * 5) / 8);
 
     let mut i = 0;
     while i < cur.len() {
@@ -84,7 +82,7 @@ pub(super) fn pack_bytes(cur: &[u8], goal: &[u8]) -> Box<[u8]> {
         i += equals * 3;
 
         if i >= cur.len() {
-            return v.into_boxed_slice();
+            return;
         }
 
         let start = i;
@@ -100,7 +98,6 @@ pub(super) fn pack_bytes(cur: &[u8], goal: &[u8]) -> Box<[u8]> {
         i += 3;
     }
     v.push(0);
-    v.into_boxed_slice()
 }
 
 #[cfg(test)]

--- a/utils/src/compression/comp/mod.rs
+++ b/utils/src/compression/comp/mod.rs
@@ -1,0 +1,5 @@
+//! This modules contains all the specialized compression functions, for each architecture, using
+//! special SIMD functions and instructions
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(super) mod sse2;

--- a/utils/src/compression/comp/sse2.rs
+++ b/utils/src/compression/comp/sse2.rs
@@ -70,7 +70,7 @@ pub(super) unsafe fn pack_bytes(cur: &[u8], goal: &[u8], v: &mut Vec<u8>) {
         i += equals * 3;
 
         if i >= cur.len() {
-            return;
+            break;
         }
 
         let start = i;
@@ -85,7 +85,11 @@ pub(super) unsafe fn pack_bytes(cur: &[u8], goal: &[u8], v: &mut Vec<u8>) {
         v.extend_from_slice(unsafe { goal.get_unchecked(start..i) });
         i += 3;
     }
-    v.push(0);
+
+    if !v.is_empty() {
+        // add one extra zero to prevent access out of bounds later during decompression
+        v.push(0)
+    }
 }
 
 #[cfg(test)]

--- a/utils/src/compression/comp/sse2.rs
+++ b/utils/src/compression/comp/sse2.rs
@@ -1,0 +1,241 @@
+#[inline]
+#[target_feature(enable = "sse2")]
+pub(in super::super) unsafe fn count_equals(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
+    use std::arch::x86_64 as intr;
+    let mut equals = 0;
+    while i + 15 < s1.len() {
+        let a = intr::_mm_loadu_si128(s1.as_ptr().add(i).cast());
+        let b = intr::_mm_loadu_si128(s2.as_ptr().add(i).cast());
+        let cmp = intr::_mm_cmpeq_epi8(a, b);
+        let mask = intr::_mm_movemask_epi8(cmp);
+        if mask != 0xFFFF {
+            equals += mask.trailing_ones() as usize / 3;
+            return equals;
+        }
+        equals += 5;
+        i += 15;
+    }
+
+    while i + 2 < s1.len() {
+        let a = unsafe { s1.get_unchecked(i..i + 3) };
+        let b = unsafe { s2.get_unchecked(i..i + 3) };
+        if a != b {
+            break;
+        }
+        equals += 1;
+        i += 3;
+    }
+    equals
+}
+
+#[inline]
+#[target_feature(enable = "sse2")]
+pub(in super::super) unsafe fn count_different(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
+    use std::arch::x86_64 as intr;
+    let mut diff = 0;
+    while i + 15 < s1.len() {
+        let a = intr::_mm_loadu_si128(s1.as_ptr().add(i).cast());
+        let b = intr::_mm_loadu_si128(s2.as_ptr().add(i).cast());
+        let cmp = intr::_mm_cmpeq_epi8(a, b);
+        let mask = intr::_mm_movemask_epi8(cmp);
+        // we only care about the case where all three bytes are equal
+        let mask = mask & (mask >> 1) & (mask >> 2);
+        if mask != 0 {
+            let tz = mask.trailing_zeros() as usize;
+            diff += (tz + 2) / 3;
+            return diff;
+        }
+        diff += 5;
+        i += 15;
+    }
+
+    while i + 2 < s1.len() {
+        let a = unsafe { s1.get_unchecked(i..i + 3) };
+        let b = unsafe { s2.get_unchecked(i..i + 3) };
+        if a == b {
+            break;
+        }
+        diff += 1;
+        i += 3;
+    }
+    diff
+}
+
+#[inline]
+#[target_feature(enable = "sse2")]
+pub(in super::super) unsafe fn pack_bytes(cur: &[u8], goal: &[u8]) -> Box<[u8]> {
+    let mut v = Vec::with_capacity((goal.len() * 5) / 8);
+
+    let mut i = 0;
+    while i < cur.len() {
+        let equals = count_equals(cur, goal, i);
+        i += equals * 3;
+
+        if i >= cur.len() {
+            return v.into_boxed_slice();
+        }
+
+        let start = i;
+        let diffs = count_different(cur, goal, i);
+        i += diffs * 3;
+
+        let j = v.len() + equals / 255;
+        v.resize(1 + j + diffs / 255, 255);
+        v[j] = (equals % 255) as u8;
+        v.push((diffs % 255) as u8);
+
+        v.extend_from_slice(unsafe { goal.get_unchecked(start..i) });
+        i += 3;
+    }
+    v.push(0);
+    v.into_boxed_slice()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compression::unpack_bytes;
+    use rand::prelude::random;
+
+    #[test]
+    fn count_equal_test() {
+        let a = [0u8; 102];
+        assert_eq!(unsafe { count_equals(&a, &a, 0) }, 102 / 3);
+        for i in [0, 10, 20, 30, 40, 50, 60, 70, 80, 90] {
+            let mut b = a;
+            b[i] = 1;
+            assert_eq!(unsafe { count_equals(&a, &b, 0) }, i / 3, "i: {i}");
+        }
+    }
+
+    #[test]
+    fn count_diffs_test() {
+        let a = [0u8; 102];
+        assert_eq!(unsafe { count_different(&a, &a, 0) }, 0,);
+        for i in [10, 20, 30, 40, 50, 60, 70, 80, 90, 102] {
+            let mut b = a;
+            for x in &mut b[..i] {
+                *x = 1;
+            }
+            assert_eq!(unsafe { count_different(&a, &b, 0) }, (i + 2) / 3, "i: {i}");
+        }
+    }
+
+    fn buf_from(slice: &[u8]) -> Vec<u8> {
+        let mut v = Vec::new();
+        for pix in slice.chunks_exact(3) {
+            v.extend_from_slice(pix);
+            v.push(255);
+        }
+        v
+    }
+
+    #[test]
+    fn small() {
+        if !is_x86_feature_detected!("sse2") {
+            return;
+        }
+        let frame1 = [1, 2, 3, 4, 5, 6];
+        let frame2 = [1, 2, 3, 6, 5, 4];
+        let compressed = unsafe { pack_bytes(&frame1, &frame2) };
+
+        let mut buf = buf_from(&frame1);
+        unpack_bytes(&mut buf, &compressed);
+        for i in 0..2 {
+            for j in 0..3 {
+                assert_eq!(
+                    frame2[i * 3 + j],
+                    buf[i * 4 + j],
+                    "\nframe2: {frame2:?}, buf: {buf:?}\n"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn total_random() {
+        if !is_x86_feature_detected!("sse2") {
+            return;
+        }
+        for _ in 0..10 {
+            let mut original = Vec::with_capacity(20);
+            for _ in 0..20 {
+                let mut v = Vec::with_capacity(3000);
+                for _ in 0..3000 {
+                    v.push(random::<u8>());
+                }
+                original.push(v);
+            }
+
+            let mut compressed = Vec::with_capacity(20);
+            compressed.push(unsafe { pack_bytes(original.last().unwrap(), &original[0]) });
+            for i in 1..20 {
+                compressed.push(unsafe { pack_bytes(&original[i - 1], &original[i]) });
+            }
+
+            let mut buf = buf_from(original.last().unwrap());
+            for i in 0..20 {
+                unpack_bytes(&mut buf, &compressed[i]);
+                let mut j = 0;
+                let mut l = 0;
+                while j < 3000 {
+                    for k in 0..3 {
+                        assert_eq!(
+                            buf[j + l + k],
+                            original[i][j + k],
+                            "Failed at index: {}",
+                            j + k
+                        );
+                    }
+                    j += 3;
+                    l += 1;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn full() {
+        if !is_x86_feature_detected!("sse2") {
+            return;
+        }
+        for _ in 0..10 {
+            let mut original = Vec::with_capacity(20);
+            for _ in 0..20 {
+                let mut v = Vec::with_capacity(3000);
+                for _ in 0..2000 {
+                    v.push(random::<u8>());
+                }
+                for i in 0..1000 {
+                    v.push((i % 255) as u8);
+                }
+                original.push(v);
+            }
+
+            let mut compressed = Vec::with_capacity(20);
+            compressed.push(unsafe { pack_bytes(original.last().unwrap(), &original[0]) });
+            for i in 1..20 {
+                compressed.push(unsafe { pack_bytes(&original[i - 1], &original[i]) });
+            }
+
+            let mut buf = buf_from(original.last().unwrap());
+            for i in 0..20 {
+                unpack_bytes(&mut buf, &compressed[i]);
+                let mut j = 0;
+                let mut l = 0;
+                while j < 3000 {
+                    for k in 0..3 {
+                        assert_eq!(
+                            buf[j + l + k],
+                            original[i][j + k],
+                            "Failed at index: {}",
+                            j + k
+                        );
+                    }
+                    j += 3;
+                    l += 1;
+                }
+            }
+        }
+    }
+}

--- a/utils/src/compression/cpu.rs
+++ b/utils/src/compression/cpu.rs
@@ -1,0 +1,34 @@
+use std::sync::Once;
+
+macro_rules! decl_feature {
+    ($feature:ident, $function:ident) => {
+        static mut $feature: bool = false;
+        #[inline(always)]
+        pub fn $function() -> bool {
+            unsafe { $feature }
+        }
+    };
+}
+
+static ONCE_INIT: Once = Once::new();
+pub(super) fn init() {
+    ONCE_INIT.call_once(|| unsafe { features::init() });
+}
+
+#[cfg(target_arch = "x86_64")]
+pub mod features {
+    decl_feature!(SSE2, sse2);
+    decl_feature!(SSSE3, ssse3);
+
+    pub(super) unsafe fn init() {
+        SSE2 = is_x86_feature_detected!("sse2");
+        SSSE3 = is_x86_feature_detected!("ssse3");
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+pub mod features {
+
+    /// do nothing for now
+    pub(super) unsafe fn init() {}
+}

--- a/utils/src/compression/cpu.rs
+++ b/utils/src/compression/cpu.rs
@@ -1,10 +1,23 @@
+//! This module detects cpu features once and caches the results in mutable statics
+//!
+//! The mutable statics are not public, and therefore they are innacessible from other modules.
+//! The only thing this module exposes are functions that let us read them, and one function to
+//! initialize them.
+//!
+//! At worst, if we forget to initialize them, they will be holding false by default, and we won't
+//! be using the more optimized versions of the relevant functions.
+
 use std::sync::Once;
 
+/// This macro declares a a cpu feature as a static mut, automatically generating a getter
+/// function for it. Using it is safe because no one can modify it outside this module
 macro_rules! decl_feature {
     ($feature:ident, $function:ident) => {
         static mut $feature: bool = false;
         #[inline(always)]
         pub fn $function() -> bool {
+            // SAFETY: we ensure this is false by default, and only changes ONCE, if someone calls
+            // this module's init() function
             unsafe { $feature }
         }
     };
@@ -12,6 +25,8 @@ macro_rules! decl_feature {
 
 static ONCE_INIT: Once = Once::new();
 pub(super) fn init() {
+    // SAFETY: features::init will modify some static mut variables. It is safe because we are
+    // wrapping them in a Once call
     ONCE_INIT.call_once(|| unsafe { features::init() });
 }
 
@@ -20,6 +35,14 @@ pub mod features {
     decl_feature!(SSE2, sse2);
     decl_feature!(SSSE3, ssse3);
 
+    /// # Safety
+    ///
+    /// This function modifies the static muts inside this module, so it mustn't be called while
+    /// someone else is trying to read them.
+    ///
+    /// That said, at worst, what will happen is that they will default to false and we won't use
+    /// the most optimized versions of some functions. The case where we will accidentally call a
+    /// function with unsupported instructions will never happen.
     pub(super) unsafe fn init() {
         SSE2 = is_x86_feature_detected!("sse2");
         SSSE3 = is_x86_feature_detected!("ssse3");
@@ -29,6 +52,7 @@ pub mod features {
 #[cfg(not(target_arch = "x86_64"))]
 pub mod features {
 
-    /// do nothing for now
+    /// UNIMPLEMENTED!!! This function must exist so that the init function in super compiles on
+    /// any target
     pub(super) unsafe fn init() {}
 }

--- a/utils/src/compression/decomp/mod.rs
+++ b/utils/src/compression/decomp/mod.rs
@@ -1,0 +1,5 @@
+//! This modules contains all the specialized decompression functions, for each architecture,
+//! using special SIMD functions and instructions
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(super) mod ssse3;

--- a/utils/src/compression/decomp/mod.rs
+++ b/utils/src/compression/decomp/mod.rs
@@ -4,6 +4,8 @@
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(super) mod ssse3;
 
+/// diff must be a slice produced by a BitPack
+/// buf must have the EXACT expected size by the BitPack
 #[inline(always)]
 pub(super) fn unpack_bytes(buf: &mut [u8], diff: &[u8]) {
     // use the most efficient implementation available:
@@ -40,6 +42,7 @@ pub(super) fn unpack_bytes(buf: &mut [u8], diff: &[u8]) {
         diff_idx += 1;
 
         for _ in 0..to_cpy {
+            // it is much faster to use this assertion for testing than miri
             debug_assert!(
                 diff_idx + 3 < diff.len(),
                 "diff_idx + 3: {}, diff.len(): {}",

--- a/utils/src/compression/decomp/mod.rs
+++ b/utils/src/compression/decomp/mod.rs
@@ -1,5 +1,47 @@
-//! This modules contains all the specialized decompression functions, for each architecture,
-//! using special SIMD functions and instructions
+//! This modules contains all the decompression functions, including the specialized ones using
+//! architecture-dependent instructions
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(super) mod ssse3;
+
+#[inline(always)]
+pub(super) fn unpack_bytes(buf: &mut [u8], diff: &[u8]) {
+    // use the most efficient implementation available:
+    #[cfg(not(test))] // when testing, we want to use the specific implementation
+    {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if super::cpu::features::ssse3() {
+            return unsafe { ssse3::unpack_bytes(buf, diff) };
+        }
+    }
+
+    let len = diff.len();
+    let buf = buf.as_mut_ptr();
+    let diff = diff.as_ptr();
+
+    let mut diff_idx = 0;
+    let mut pix_idx = 0;
+    while diff_idx + 1 < len {
+        while unsafe { diff.add(diff_idx).read() } == u8::MAX {
+            pix_idx += u8::MAX as usize;
+            diff_idx += 1;
+        }
+        pix_idx += unsafe { diff.add(diff_idx).read() } as usize;
+        diff_idx += 1;
+
+        let mut to_cpy = 0;
+        while unsafe { diff.add(diff_idx).read() } == u8::MAX {
+            to_cpy += u8::MAX as usize;
+            diff_idx += 1;
+        }
+        to_cpy += unsafe { diff.add(diff_idx).read() } as usize;
+        diff_idx += 1;
+
+        for _ in 0..to_cpy {
+            unsafe { std::ptr::copy_nonoverlapping(diff.add(diff_idx), buf.add(pix_idx * 4), 4) }
+            diff_idx += 3;
+            pix_idx += 1;
+        }
+        pix_idx += 1;
+    }
+}

--- a/utils/src/compression/decomp/ssse3.rs
+++ b/utils/src/compression/decomp/ssse3.rs
@@ -66,7 +66,8 @@ mod tests {
         }
         let frame1 = [1, 2, 3, 4, 5, 6];
         let frame2 = [1, 2, 3, 6, 5, 4];
-        let compressed = pack_bytes(&frame1, &frame2);
+        let mut compressed = Vec::new();
+        pack_bytes(&frame1, &frame2, &mut compressed);
 
         let mut buf = buf_from(&frame1);
         unsafe { unpack_bytes(&mut buf, &compressed) }
@@ -97,9 +98,13 @@ mod tests {
             }
 
             let mut compressed = Vec::with_capacity(20);
-            compressed.push(pack_bytes(original.last().unwrap(), &original[0]));
+            let mut buf = Vec::new();
+            pack_bytes(original.last().unwrap(), &original[0], &mut buf);
+            compressed.push(buf.clone().into_boxed_slice());
             for i in 1..20 {
-                compressed.push(pack_bytes(&original[i - 1], &original[i]));
+                buf.clear();
+                pack_bytes(&original[i - 1], &original[i], &mut buf);
+                compressed.push(buf.clone().into_boxed_slice());
             }
 
             let mut buf = buf_from(original.last().unwrap());
@@ -148,9 +153,13 @@ mod tests {
             }
 
             let mut compressed = Vec::with_capacity(20);
-            compressed.push(pack_bytes(original.last().unwrap(), &original[0]));
+            let mut buf = Vec::new();
+            pack_bytes(original.last().unwrap(), &original[0], &mut buf);
+            compressed.push(buf.clone().into_boxed_slice());
             for i in 1..20 {
-                compressed.push(pack_bytes(&original[i - 1], &original[i]));
+                buf.clear();
+                pack_bytes(&original[i - 1], &original[i], &mut buf);
+                compressed.push(buf.clone().into_boxed_slice());
             }
 
             let mut buf = buf_from(original.last().unwrap());

--- a/utils/src/compression/decomp/ssse3.rs
+++ b/utils/src/compression/decomp/ssse3.rs
@@ -75,7 +75,7 @@ mod tests {
         let frame1 = [1, 2, 3, 4, 5, 6];
         let frame2 = [1, 2, 3, 6, 5, 4];
         let mut compressed = Vec::new();
-        pack_bytes(&frame1, &frame2, &mut compressed);
+        unsafe { pack_bytes(&frame1, &frame2, &mut compressed) }
 
         let mut buf = buf_from(&frame1);
         unsafe { unpack_bytes(&mut buf, &compressed) }
@@ -107,11 +107,11 @@ mod tests {
 
             let mut compressed = Vec::with_capacity(20);
             let mut buf = Vec::new();
-            pack_bytes(original.last().unwrap(), &original[0], &mut buf);
+            unsafe { pack_bytes(original.last().unwrap(), &original[0], &mut buf) }
             compressed.push(buf.clone().into_boxed_slice());
             for i in 1..20 {
                 buf.clear();
-                pack_bytes(&original[i - 1], &original[i], &mut buf);
+                unsafe { pack_bytes(&original[i - 1], &original[i], &mut buf) }
                 compressed.push(buf.clone().into_boxed_slice());
             }
 
@@ -162,11 +162,11 @@ mod tests {
 
             let mut compressed = Vec::with_capacity(20);
             let mut buf = Vec::new();
-            pack_bytes(original.last().unwrap(), &original[0], &mut buf);
+            unsafe { pack_bytes(original.last().unwrap(), &original[0], &mut buf) }
             compressed.push(buf.clone().into_boxed_slice());
             for i in 1..20 {
                 buf.clear();
-                pack_bytes(&original[i - 1], &original[i], &mut buf);
+                unsafe { pack_bytes(&original[i - 1], &original[i], &mut buf) }
                 compressed.push(buf.clone().into_boxed_slice());
             }
 

--- a/utils/src/compression/decomp/ssse3.rs
+++ b/utils/src/compression/decomp/ssse3.rs
@@ -1,6 +1,6 @@
 #[inline]
 #[target_feature(enable = "ssse3")]
-pub(in super::super) unsafe fn unpack_bytes(buf: &mut [u8], diff: &[u8]) {
+pub(super) unsafe fn unpack_bytes(buf: &mut [u8], diff: &[u8]) {
     use std::arch::x86_64 as intr;
 
     let len = diff.len();
@@ -132,10 +132,16 @@ mod tests {
             let mut original = Vec::with_capacity(20);
             for _ in 0..20 {
                 let mut v = Vec::with_capacity(3000);
-                for _ in 0..2000 {
+                for _ in 0..750 {
                     v.push(random::<u8>());
                 }
-                for i in 0..1000 {
+                for i in 0..750 {
+                    v.push((i % 255) as u8);
+                }
+                for _ in 0..750 {
+                    v.push(random::<u8>());
+                }
+                for i in 0..750 {
                     v.push((i % 255) as u8);
                 }
                 original.push(v);

--- a/utils/src/compression/decomp/ssse3.rs
+++ b/utils/src/compression/decomp/ssse3.rs
@@ -1,0 +1,170 @@
+#[inline]
+#[target_feature(enable = "ssse3")]
+pub(in super::super) unsafe fn unpack_bytes(buf: &mut [u8], diff: &[u8]) {
+    use std::arch::x86_64 as intr;
+
+    let len = diff.len();
+    let buf = buf.as_mut_ptr();
+    let diff = diff.as_ptr();
+    let mask = intr::_mm_set_epi8(-1, 11, 10, 9, -1, 8, 7, 6, -1, 5, 4, 3, -1, 2, 1, 0);
+
+    let mut diff_idx = 0;
+    let mut pix_idx = 0;
+    while diff_idx + 1 < len {
+        while diff.add(diff_idx).read() == u8::MAX {
+            pix_idx += u8::MAX as usize;
+            diff_idx += 1;
+        }
+        pix_idx += diff.add(diff_idx).read() as usize;
+        diff_idx += 1;
+
+        let mut to_cpy = 0;
+        while diff.add(diff_idx).read() == u8::MAX {
+            to_cpy += u8::MAX as usize;
+            diff_idx += 1;
+        }
+        to_cpy += diff.add(diff_idx).read() as usize;
+        diff_idx += 1;
+
+        while to_cpy > 4 {
+            let d = intr::_mm_loadu_si128(diff.add(diff_idx).cast());
+            let to_store = intr::_mm_shuffle_epi8(d, mask);
+            intr::_mm_storeu_si128(buf.add(pix_idx * 4).cast(), to_store);
+
+            diff_idx += 12;
+            pix_idx += 4;
+            to_cpy -= 4;
+        }
+        for _ in 0..to_cpy {
+            std::ptr::copy_nonoverlapping(diff.add(diff_idx), buf.add(pix_idx * 4), 4);
+            diff_idx += 3;
+            pix_idx += 1;
+        }
+        pix_idx += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compression::pack_bytes;
+    use rand::prelude::random;
+
+    fn buf_from(slice: &[u8]) -> Vec<u8> {
+        let mut v = Vec::new();
+        for pix in slice.chunks_exact(3) {
+            v.extend_from_slice(pix);
+            v.push(255);
+        }
+        v
+    }
+
+    #[test]
+    fn small() {
+        if !is_x86_feature_detected!("ssse3") {
+            return;
+        }
+        let frame1 = [1, 2, 3, 4, 5, 6];
+        let frame2 = [1, 2, 3, 6, 5, 4];
+        let compressed = pack_bytes(&frame1, &frame2);
+
+        let mut buf = buf_from(&frame1);
+        unsafe { unpack_bytes(&mut buf, &compressed) }
+        for i in 0..2 {
+            for j in 0..3 {
+                assert_eq!(
+                    frame2[i * 3 + j],
+                    buf[i * 4 + j],
+                    "\nframe2: {frame2:?}, buf: {buf:?}\n"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn total_random() {
+        if !is_x86_feature_detected!("ssse3") {
+            return;
+        }
+        for _ in 0..10 {
+            let mut original = Vec::with_capacity(20);
+            for _ in 0..20 {
+                let mut v = Vec::with_capacity(3000);
+                for _ in 0..3000 {
+                    v.push(random::<u8>());
+                }
+                original.push(v);
+            }
+
+            let mut compressed = Vec::with_capacity(20);
+            compressed.push(pack_bytes(original.last().unwrap(), &original[0]));
+            for i in 1..20 {
+                compressed.push(pack_bytes(&original[i - 1], &original[i]));
+            }
+
+            let mut buf = buf_from(original.last().unwrap());
+            for i in 0..20 {
+                unsafe { unpack_bytes(&mut buf, &compressed[i]) }
+                let mut j = 0;
+                let mut l = 0;
+                while j < 3000 {
+                    for k in 0..3 {
+                        assert_eq!(
+                            buf[j + l + k],
+                            original[i][j + k],
+                            "Failed at index: {}",
+                            j + k
+                        );
+                    }
+                    j += 3;
+                    l += 1;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn full() {
+        if !is_x86_feature_detected!("ssse3") {
+            return;
+        }
+        for _ in 0..10 {
+            let mut original = Vec::with_capacity(20);
+            for _ in 0..20 {
+                let mut v = Vec::with_capacity(3000);
+                for _ in 0..2000 {
+                    v.push(random::<u8>());
+                }
+                for i in 0..1000 {
+                    v.push((i % 255) as u8);
+                }
+                original.push(v);
+            }
+
+            let mut compressed = Vec::with_capacity(20);
+            compressed.push(pack_bytes(original.last().unwrap(), &original[0]));
+            for i in 1..20 {
+                compressed.push(pack_bytes(&original[i - 1], &original[i]));
+            }
+
+            let mut buf = buf_from(original.last().unwrap());
+            for i in 0..20 {
+                unsafe { unpack_bytes(&mut buf, &compressed[i]) }
+                let mut j = 0;
+                let mut l = 0;
+                while j < 3000 {
+                    for k in 0..3 {
+                        assert_eq!(
+                            buf[j + l + k],
+                            original[i][j + k],
+                            "Failed at index: {}",
+                            j + k
+                        );
+                    }
+                    j += 3;
+                    l += 1;
+                }
+            }
+        }
+    }
+}

--- a/utils/src/compression/mod.rs
+++ b/utils/src/compression/mod.rs
@@ -14,12 +14,139 @@
 //! * Then, we store all the new bytes.
 //! * Start from the top until we are done with the image
 //!
+//! The default implementation lies in this file. Architecture-specific implementations that make
+//! use of specialized instructions lie in other submodules.
 
 use lzzzz::lz4f;
 use rkyv::{Archive, Deserialize, Serialize};
+mod comp;
+mod cpu;
+mod decomp;
 
+/// This struct represents the cached difference between the previous frame and the next
+#[derive(Archive, Serialize, Deserialize)]
+pub struct BitPack {
+    inner: Box<[u8]>,
+    /// This field will ensure we won't ever try to unpack the images on a buffer of the wrong size,
+    /// which ultimately is what allows us to use unsafe in the unpack_bytes function
+    expected_buf_size: usize,
+}
+
+/// Struct responsible for compressing our data. We use it to cache vector extensions that might
+/// speed up compression, as well as our lz4 compression configuration preferences
+#[derive(Default)]
+pub struct Compressor {
+    preferences: lz4f::Preferences,
+}
+
+impl Compressor {
+    pub fn new() -> Self {
+        cpu::init();
+        Self {
+            preferences: lz4f::PreferencesBuilder::new()
+                .block_size(lz4f::BlockSize::Max256KB)
+                .compression_level(9)
+                .build(),
+        }
+    }
+
+    /// Compresses a frame of animation by getting the difference between the previous and the
+    /// current frame, and then running lz4
+    pub fn compress(&self, prev: &[u8], cur: &[u8]) -> Result<BitPack, String> {
+        assert_eq!(
+            prev.len(),
+            cur.len(),
+            "swww cannot currently deal with animations whose frames have different sizes!"
+        );
+
+        let bit_pack = 'pack: {
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            if cpu::features::sse2() {
+                break 'pack (unsafe { comp::sse2::pack_bytes(prev, cur) });
+            }
+            pack_bytes(prev, cur)
+        };
+
+        if bit_pack.is_empty() {
+            return Ok(BitPack {
+                inner: Box::new([]),
+                expected_buf_size: (cur.len() / 3) * 4,
+            });
+        }
+
+        let mut v = Vec::with_capacity(bit_pack.len() / 2);
+        lz4f::compress_to_vec(&bit_pack, &mut v, &self.preferences).map_err(|e| e.to_string())?;
+        Ok(BitPack {
+            inner: v.into_boxed_slice(),
+            expected_buf_size: (cur.len() / 3) * 4,
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct Decompressor;
+
+impl Decompressor {
+    pub fn new() -> Self {
+        cpu::init();
+        Self {}
+    }
+
+    ///returns whether unpacking was successful. Note it can only fail if `buf.len() !=
+    ///expected_buf_size`
+    pub fn decompress(&self, bitpack: &BitPack, buf: &mut [u8]) -> bool {
+        if buf.len() == bitpack.expected_buf_size {
+            if !bitpack.inner.is_empty() {
+                let mut v = Vec::with_capacity(bitpack.inner.len() * 3);
+                // Note: panics will never happen because BitPacked is *always* only produced
+                // with correct lz4 compression
+                lz4f::decompress_to_vec(&bitpack.inner, &mut v).unwrap();
+
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                if cpu::features::ssse3() {
+                    unsafe { decomp::ssse3::unpack_bytes(buf, &v) }
+                    return true;
+                }
+                unpack_bytes(buf, &v);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    ///returns whether unpacking was successful. Note it can only fail if `buf.len() !=
+    ///expected_buf_size`
+    ///This function is identical to its non-archived counterpart
+    pub fn decompress_archived(&self, archived: &ArchivedBitPack, buf: &mut [u8]) -> bool {
+        let expected_len: usize = archived
+            .expected_buf_size
+            .deserialize(&mut rkyv::Infallible)
+            .unwrap();
+        if buf.len() == expected_len {
+            if !archived.inner.is_empty() {
+                let mut v = Vec::with_capacity(archived.inner.len() * 3);
+                // Note: panics will never happen because BitPacked is *always* only produced
+                // with correct lz4 compression
+                lz4f::decompress_to_vec(&archived.inner, &mut v).unwrap();
+
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                if cpu::features::ssse3() {
+                    unsafe { decomp::ssse3::unpack_bytes(buf, &v) }
+                    return true;
+                }
+                unpack_bytes(buf, &v);
+            }
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// SAFETY: s1.len() must be equal to s2.len()
 #[inline(always)]
-fn count_equals(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
+unsafe fn count_equals(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
     let mut equals = 0;
     while i + 7 < s1.len() {
         let a: u64 = unsafe { s1.as_ptr().add(i).cast::<u64>().read_unaligned() };
@@ -45,8 +172,9 @@ fn count_equals(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
     equals
 }
 
+/// SAFETY: s1.len() must be equal to s2.len()
 #[inline(always)]
-fn count_different(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
+unsafe fn count_different(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
     let mut different = 0;
     while i + 2 < s1.len() {
         let a = unsafe { s1.get_unchecked(i..i + 3) };
@@ -61,12 +189,13 @@ fn count_different(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
 }
 
 /// This calculates the difference between the current(cur) frame and the next(goal)
-pub fn pack_bytes(cur: &[u8], goal: &[u8]) -> Box<[u8]> {
+#[inline]
+fn pack_bytes(cur: &[u8], goal: &[u8]) -> Box<[u8]> {
     let mut v = Vec::with_capacity((goal.len() * 5) / 8);
 
     let mut i = 0;
     while i < cur.len() {
-        let equals = count_equals(cur, goal, i);
+        let equals = unsafe { count_equals(cur, goal, i) };
         i += equals * 3;
 
         if i >= cur.len() {
@@ -74,7 +203,7 @@ pub fn pack_bytes(cur: &[u8], goal: &[u8]) -> Box<[u8]> {
         }
 
         let start = i;
-        let diffs = count_different(cur, goal, i);
+        let diffs = unsafe { count_different(cur, goal, i) };
         i += diffs * 3;
 
         let j = v.len() + equals / 255;
@@ -121,107 +250,34 @@ fn unpack_bytes(buf: &mut [u8], diff: &[u8]) {
     }
 }
 
-/// Struct responsible for compressing our data. We use it to cache vector extensions that might
-/// speed up compression, as well as our lz4 compression configuration preferences
-#[derive(Default)]
-pub struct Compressor {
-    preferences: lz4f::Preferences,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    ssse3_support: bool,
-}
-
-impl Compressor {
-    pub fn new() -> Self {
-        Self {
-            preferences: lz4f::PreferencesBuilder::new()
-                .block_size(lz4f::BlockSize::Max256KB)
-                .compression_level(9)
-                .build(),
-
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            ssse3_support: is_x86_feature_detected!("ssse3"),
-        }
-    }
-
-    /// Compresses a frame of animation by getting the difference between the previous and the
-    /// current frame, and then running lz4
-    pub fn compress(&self, prev: &[u8], cur: &[u8]) -> Result<BitPack, String> {
-        let bit_pack = pack_bytes(prev, cur);
-
-        if bit_pack.is_empty() {
-            return Ok(BitPack {
-                inner: Box::new([]),
-                expected_buf_size: (cur.len() / 3) * 4,
-            });
-        }
-
-        let mut v = Vec::with_capacity(bit_pack.len() / 2);
-        lz4f::compress_to_vec(&bit_pack, &mut v, &self.preferences).map_err(|e| e.to_string())?;
-        Ok(BitPack {
-            inner: v.into_boxed_slice(),
-            expected_buf_size: (cur.len() / 3) * 4,
-        })
-    }
-}
-
-/// This struct represents the cached difference between the previous frame and the next
-#[derive(Archive, Serialize, Deserialize)]
-pub struct BitPack {
-    inner: Box<[u8]>,
-    /// This field will ensure we won't ever try to unpack the images on a buffer of the wrong size,
-    /// which ultimately is what allows us to use unsafe in the unpack_bytes function
-    expected_buf_size: usize,
-}
-
-impl BitPack {
-    ///return whether unpacking was successful. Note it can only fail if `buf.len() !=
-    ///expected_buf_size`
-    #[must_use]
-    pub fn unpack(&self, buf: &mut [u8]) -> bool {
-        if buf.len() == self.expected_buf_size {
-            if !self.inner.is_empty() {
-                let mut v = Vec::with_capacity(self.inner.len() * 3);
-                // Note: panics will never happen because BitPacked is *always* only produced
-                // with correct lz4 compression
-                lz4f::decompress_to_vec(&self.inner, &mut v).unwrap();
-                unpack_bytes(buf, &v);
-            }
-            true
-        } else {
-            false
-        }
-    }
-}
-
-impl ArchivedBitPack {
-    ///return whether unpacking was successful. Note it can only fail if `buf.len() !=
-    ///expected_buf_size`
-    ///This function is identical to its NonArchived counterpart
-    #[must_use]
-    pub fn unpack(&self, buf: &mut [u8]) -> bool {
-        let expected_len = self
-            .expected_buf_size
-            .deserialize(&mut rkyv::Infallible)
-            .unwrap();
-        if buf.len() == expected_len {
-            if !self.inner.is_empty() {
-                let mut v = Vec::with_capacity(self.inner.len() * 3);
-                // Note: panics will never happen because BitPacked is *always* only produced
-                // with correct lz4 compression
-                lz4f::decompress_to_vec(&self.inner, &mut v).unwrap();
-                unpack_bytes(buf, &v);
-            }
-            true
-        } else {
-            false
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use rand::prelude::random;
+
+    #[test]
+    fn count_equal_test() {
+        let a = [0u8; 102];
+        assert_eq!(unsafe { count_equals(&a, &a, 0) }, 102 / 3);
+        for i in [0, 10, 20, 30, 40, 50, 60, 70, 80, 90] {
+            let mut b = a;
+            b[i] = 1;
+            assert_eq!(unsafe { count_equals(&a, &b, 0) }, i / 3, "i: {i}");
+        }
+    }
+
+    #[test]
+    fn count_diffs_test() {
+        let a = [0u8; 102];
+        assert_eq!(unsafe { count_different(&a, &a, 0) }, 0,);
+        for i in [10, 20, 30, 40, 50, 60, 70, 80, 90, 102] {
+            let mut b = a;
+            for x in &mut b[..i] {
+                *x = 1;
+            }
+            assert_eq!(unsafe { count_different(&a, &b, 0) }, (i + 2) / 3, "i: {i}");
+        }
+    }
 
     fn buf_from(slice: &[u8]) -> Vec<u8> {
         let mut v = Vec::new();
@@ -234,13 +290,13 @@ mod tests {
 
     #[test]
     //Use this when annoying problems show up
-    fn should_compress_and_decompress_to_same_info_small() {
+    fn small() {
         let frame1 = [1, 2, 3, 4, 5, 6];
         let frame2 = [1, 2, 3, 6, 5, 4];
         let compressed = Compressor::new().compress(&frame1, &frame2).unwrap();
 
         let mut buf = buf_from(&frame1);
-        assert!(compressed.unpack(&mut buf));
+        assert!(Decompressor::new().decompress(&compressed, &mut buf));
         for i in 0..2 {
             for j in 0..3 {
                 assert_eq!(
@@ -253,7 +309,7 @@ mod tests {
     }
 
     #[test]
-    fn should_compress_and_decompress_to_same_info() {
+    fn total_random() {
         for _ in 0..10 {
             let mut original = Vec::with_capacity(20);
             for _ in 0..20 {
@@ -266,6 +322,7 @@ mod tests {
 
             let mut compressed = Vec::with_capacity(20);
             let compressor = Compressor::new();
+            let decompressor = Decompressor::new();
             compressed.push(
                 compressor
                     .compress(original.last().unwrap(), &original[0])
@@ -277,7 +334,7 @@ mod tests {
 
             let mut buf = buf_from(original.last().unwrap());
             for i in 0..20 {
-                assert!(compressed[i].unpack(&mut buf));
+                assert!(decompressor.decompress(&compressed[i], &mut buf));
                 let mut j = 0;
                 let mut l = 0;
                 while j < 3000 {
@@ -297,21 +354,28 @@ mod tests {
     }
 
     #[test]
-    fn should_compress_and_decompress_to_same_info_with_equal_data() {
+    fn full() {
         for _ in 0..10 {
             let mut original = Vec::with_capacity(20);
             for _ in 0..20 {
                 let mut v = Vec::with_capacity(3000);
-                for _ in 0..2000 {
+                for _ in 0..750 {
                     v.push(random::<u8>());
                 }
-                for i in 0..1000 {
+                for i in 0..750 {
+                    v.push((i % 255) as u8);
+                }
+                for _ in 0..750 {
+                    v.push(random::<u8>());
+                }
+                for i in 0..750 {
                     v.push((i % 255) as u8);
                 }
                 original.push(v);
             }
 
             let compressor = Compressor::new();
+            let decompressor = Decompressor::new();
             let mut compressed = Vec::with_capacity(20);
             compressed.push(
                 compressor
@@ -324,7 +388,7 @@ mod tests {
 
             let mut buf = buf_from(original.last().unwrap());
             for i in 0..20 {
-                assert!(compressed[i].unpack(&mut buf));
+                assert!(decompressor.decompress(&compressed[i], &mut buf));
                 let mut j = 0;
                 let mut l = 0;
                 while j < 3000 {

--- a/utils/src/ipc.rs
+++ b/utils/src/ipc.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use crate::{cache, comp_decomp::BitPack};
+use crate::{cache, compression::BitPack};
 
 #[derive(PartialEq, Archive, Serialize)]
 #[archive_attr(derive(Clone))]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod cache;
-pub mod comp_decomp;
+pub mod compression;
 pub mod ipc;


### PR DESCRIPTION
This overhauls the current api for compressing animated frames.

The new api is more explicit about errors, does better checking for preconditions, and is faster.

We've dropped `lzzzz` in favor of just linking the lz4 system library directly. lz4 was already listed as one of our dependencies, so this should be fine.

We've also included hand-written SIMD implementations to further speed up both compression and decompression. Note that LZ4 takes the most amount of time when it comes to compression and decompression, so, even though this is nice, it won't make a world of difference.