### PR TITLE
fix gif animations overlapping when sending two gifs

### DIFF
--- a/daemon/src/animations/mod.rs
+++ b/daemon/src/animations/mod.rs
@@ -114,7 +114,7 @@ impl Animator {
 
                 for (wallpaper, token) in wallpapers.iter().zip(&tokens) {
                     loop {
-                        if !wallpaper.has_animation_id(token) || token.transition_finished() {
+                        if !wallpaper.has_animation_id(token) || token.is_transition_done() {
                             break;
                         }
                         let duration: Duration = animation.animation[0]

--- a/daemon/src/animations/transitions.rs
+++ b/daemon/src/animations/transitions.rs
@@ -103,6 +103,9 @@ impl Transition {
             ArchivedTransitionType::Fade => self.fade(new_img),
         };
         debug!("Transitions finished");
+        for (wallpaper, token) in self.wallpapers.iter().zip(self.animation_tokens) {
+            token.set_transition_done(wallpaper);
+        }
     }
 
     fn send_frame(&mut self, now: &mut Instant) {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -296,7 +296,7 @@ impl Daemon {
                     .name("clear".to_string())
                     .spawn(move || {
                         for wallpaper in &wallpapers {
-                            wallpaper.inc_animation_id();
+                            wallpaper.stop_animations();
                         }
                         for wallpaper in wallpapers {
                             wallpaper.set_img_info(utils::ipc::BgImg::Color(color));
@@ -325,7 +325,7 @@ impl Daemon {
                 for img in imgs.iter() {
                     let mut wallpapers = self.find_wallpapers_by_names(&img.1);
                     for wallpaper in wallpapers.iter_mut() {
-                        wallpaper.inc_animation_id();
+                        wallpaper.stop_animations();
                     }
                     used_wallpapers.push(wallpapers);
                 }


### PR DESCRIPTION
Gif animations were overlapping when an animated gif was sent while another animated gif was being displayed. This happened because we were setting `transition-finished` to `true` automatically when the animation token was dropped. So, when the previous gif animation stopped, it would drop the token and set `transition-finished` to true, even though the transition hadn't finished yet.

This patch sets `transition-finished` manually, only for the transitions that actually finished.

Fixes #188.