### PR TITLE
wait for daemon initialization before certain requests

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -309,7 +309,7 @@ impl Daemon {
                     Err(e) => Answer::Err(format!("failed to spawn `clear` thread: {e}")),
                 }
             }
-            ArchivedRequest::Init => Answer::Init(
+            ArchivedRequest::Ping => Answer::Ping(
                 self.wallpapers
                     .iter()
                     .all(|w| w.configured.load(std::sync::atomic::Ordering::Acquire)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,20 +49,18 @@ fn main() -> Result<(), String> {
         }
     }
 
-    if let Swww::Init { .. } | Swww::Img(_) | Swww::Restore(_) | Swww::Clear(_) = &swww {
-        let mut configured = false;
-        while !configured {
-            let socket = connect_to_socket(5, 100)?;
-            Request::Init.send(&socket)?;
-            let bytes = read_socket(&socket)?;
-            let answer = Answer::receive(&bytes);
-            if let ArchivedAnswer::Init(c) = answer {
-                configured = *c;
-            } else {
-                return Err("Daemon did not return Answer::Init, as expected".to_string());
-            }
-            std::thread::sleep(Duration::from_millis(1));
+    let mut configured = false;
+    while !configured {
+        let socket = connect_to_socket(5, 100)?;
+        Request::Init.send(&socket)?;
+        let bytes = read_socket(&socket)?;
+        let answer = Answer::receive(&bytes);
+        if let ArchivedAnswer::Init(c) = answer {
+            configured = *c;
+        } else {
+            return Err("Daemon did not return Answer::Init, as expected".to_string());
         }
+        std::thread::sleep(Duration::from_millis(1));
     }
 
     process_swww_args(&swww)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,13 +52,13 @@ fn main() -> Result<(), String> {
     let mut configured = false;
     while !configured {
         let socket = connect_to_socket(5, 100)?;
-        Request::Init.send(&socket)?;
+        Request::Ping.send(&socket)?;
         let bytes = read_socket(&socket)?;
         let answer = Answer::receive(&bytes);
-        if let ArchivedAnswer::Init(c) = answer {
+        if let ArchivedAnswer::Ping(c) = answer {
             configured = *c;
         } else {
-            return Err("Daemon did not return Answer::Init, as expected".to_string());
+            return Err("Daemon did not return Answer::Ping, as expected".to_string());
         }
         std::thread::sleep(Duration::from_millis(1));
     }
@@ -98,7 +98,7 @@ fn process_swww_args(args: &Swww) -> Result<(), String> {
                 ));
             }
         }
-        ArchivedAnswer::Init(_) => {
+        ArchivedAnswer::Ping(_) => {
             return Ok(());
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,22 @@ fn main() -> Result<(), String> {
         }
     }
 
+    if let Swww::Init { .. } | Swww::Img(_) | Swww::Restore(_) | Swww::Clear(_) = &swww {
+        let mut configured = false;
+        while !configured {
+            let socket = connect_to_socket(5, 100)?;
+            Request::Init.send(&socket)?;
+            let bytes = read_socket(&socket)?;
+            let answer = Answer::receive(&bytes);
+            if let ArchivedAnswer::Init(c) = answer {
+                configured = *c;
+            } else {
+                return Err("Daemon did not return Answer::Init, as expected".to_string());
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
+
     process_swww_args(&swww)?;
 
     Ok(())
@@ -84,25 +100,8 @@ fn process_swww_args(args: &Swww) -> Result<(), String> {
                 ));
             }
         }
-        ArchivedAnswer::Init(configured) => {
-            let mut configured = *configured;
-            while !configured {
-                std::thread::sleep(Duration::from_millis(1));
-                let socket = connect_to_socket(5, 100)?;
-                Request::Init.send(&socket)?;
-                let bytes = read_socket(&socket)?;
-                let answer = Answer::receive(&bytes);
-                if let ArchivedAnswer::Init(c) = answer {
-                    configured = *c;
-                } else {
-                    return Err("Daemon did not return Answer::Init, as expected".to_string());
-                }
-            }
-            if let Swww::Init { no_cache, .. } = args {
-                if !*no_cache {
-                    restore_from_cache(&[])?;
-                }
-            }
+        ArchivedAnswer::Init(_) => {
+            return Ok(());
         }
     }
     Ok(())
@@ -159,7 +158,12 @@ fn make_request(args: &Swww) -> Result<Option<Request>, String> {
                 )?)))
             }
         }
-        Swww::Init { .. } => Ok(Some(Request::Init)),
+        Swww::Init { no_cache, .. } => {
+            if !*no_cache {
+                restore_from_cache(&[])?;
+            }
+            Ok(None)
+        }
         Swww::Kill => Ok(Some(Request::Kill)),
         Swww::Query => Ok(Some(Request::Query)),
     }

--- a/utils/src/ipc.rs
+++ b/utils/src/ipc.rs
@@ -217,7 +217,7 @@ pub type ImageRequest = (Transition, Box<[(Img, Box<[String]>)]>);
 pub enum Request {
     Animation(AnimationRequest),
     Clear(Clear),
-    Init,
+    Ping,
     Kill,
     Query,
     Img(ImageRequest),
@@ -272,7 +272,7 @@ pub enum Answer {
     Ok,
     Err(String),
     Info(Box<[BgInfo]>),
-    Init(bool),
+    Ping(bool),
 }
 
 impl Answer {


### PR DESCRIPTION
`swww {init,img,restore,clear}` now waits for the daemon to initialize before making the request.

Not sure if this is the best approach, but it seems to work ok.

Fix: https://github.com/LGFae/swww/issues/224