### PR TITLE
Use 3channel format

### DIFF
--- a/daemon/src/animations/mod.rs
+++ b/daemon/src/animations/mod.rs
@@ -149,7 +149,7 @@ impl Animator {
                         }
 
                         let result = wallpapers[i].canvas_change(|canvas| {
-                            decompressor.decompress_archived(frame, canvas)
+                            decompressor.decompress_archived(frame, canvas, crate::pixel_format())
                         });
 
                         if let Err(e) = result {

--- a/daemon/src/animations/transitions.rs
+++ b/daemon/src/animations/transitions.rs
@@ -55,6 +55,7 @@ pub(super) struct Transition {
     bezier: BezierCurve,
     wave: (f32, f32),
     invert_y: bool,
+    color_channels: usize,
 }
 
 /// All transitions return whether or not they completed
@@ -89,6 +90,7 @@ impl Transition {
             ),
             wave: transition.wave,
             invert_y: transition.invert_y,
+            color_channels: crate::pixel_format().channels() as usize,
         }
     }
 
@@ -141,7 +143,10 @@ impl Transition {
             done = true;
             for wallpaper in self.wallpapers.iter_mut() {
                 wallpaper.canvas_change(|canvas| {
-                    for (old, new) in canvas.chunks_exact_mut(4).zip(new_img.chunks_exact(3)) {
+                    for (old, new) in canvas
+                        .chunks_exact_mut(self.color_channels)
+                        .zip(new_img.chunks_exact(3))
+                    {
                         change_cols!(step, old, new, done);
                     }
                 });
@@ -160,7 +165,7 @@ impl Transition {
             for wallpaper in self.wallpapers.iter_mut() {
                 wallpaper.canvas_change(|canvas| {
                     canvas
-                        .par_chunks_exact_mut(4)
+                        .par_chunks_exact_mut(self.color_channels)
                         .zip(new_img.par_chunks_exact(3))
                         .for_each(|(old_pix, new_pix)| {
                             for (old_col, new_col) in old_pix.iter_mut().zip(new_pix) {
@@ -229,7 +234,7 @@ impl Transition {
             for wallpaper in self.wallpapers.iter_mut() {
                 wallpaper.canvas_change(|canvas| {
                     canvas
-                        .par_chunks_exact_mut(4)
+                        .par_chunks_exact_mut(self.color_channels)
                         .zip(new_img.par_chunks_exact(3))
                         .enumerate()
                         .for_each(|(i, (old, new))| {
@@ -290,7 +295,7 @@ impl Transition {
             for wallpaper in self.wallpapers.iter_mut() {
                 wallpaper.canvas_change(|canvas| {
                     canvas
-                        .par_chunks_exact_mut(4)
+                        .par_chunks_exact_mut(self.color_channels)
                         .zip(new_img.par_chunks_exact(3))
                         .enumerate()
                         .for_each(|(i, (old, new))| {
@@ -337,7 +342,7 @@ impl Transition {
             for wallpaper in self.wallpapers.iter_mut() {
                 wallpaper.canvas_change(|canvas| {
                     canvas
-                        .par_chunks_exact_mut(4)
+                        .par_chunks_exact_mut(self.color_channels)
                         .zip(new_img.par_chunks_exact(3))
                         .enumerate()
                         .for_each(|(i, (old, new))| {
@@ -388,7 +393,7 @@ impl Transition {
             for wallpaper in self.wallpapers.iter_mut() {
                 wallpaper.canvas_change(|canvas| {
                     canvas
-                        .par_chunks_exact_mut(4)
+                        .par_chunks_exact_mut(self.color_channels)
                         .zip(new_img.par_chunks_exact(3))
                         .enumerate()
                         .for_each(|(i, (old, new))| {

--- a/daemon/src/bump_pool.rs
+++ b/daemon/src/bump_pool.rs
@@ -4,10 +4,7 @@ use std::sync::{
 };
 
 use smithay_client_toolkit::shm::{raw::RawPool, Shm};
-use wayland_client::{
-    protocol::{wl_buffer::WlBuffer, wl_shm},
-    QueueHandle,
-};
+use wayland_client::{protocol::wl_buffer::WlBuffer, QueueHandle};
 
 use crate::Daemon;
 
@@ -53,7 +50,7 @@ impl BumpPool {
                 width,
                 height,
                 width * 4,
-                wl_shm::Format::Xrgb8888,
+                crate::wl_shm_format(),
                 released.clone(),
                 qh,
             ),
@@ -99,7 +96,7 @@ impl BumpPool {
                 self.width,
                 self.height,
                 self.width * 4,
-                wl_shm::Format::Xrgb8888,
+                crate::wl_shm_format(),
                 released.clone(),
                 qh,
             ),
@@ -165,7 +162,7 @@ impl BumpPool {
                 width,
                 height,
                 width * 4,
-                wl_shm::Format::Xrgb8888,
+                crate::wl_shm_format(),
                 released.clone(),
                 qh,
             ),

--- a/daemon/src/bump_pool.rs
+++ b/daemon/src/bump_pool.rs
@@ -41,7 +41,7 @@ pub(crate) struct BumpPool {
 impl BumpPool {
     /// We assume `width` and `height` have already been multiplied by their scale factor
     pub(crate) fn new(width: i32, height: i32, shm: &Shm, qh: &QueueHandle<Daemon>) -> Self {
-        let len = width as usize * height as usize * 4;
+        let len = width as usize * height as usize * crate::pixel_format().channels() as usize;
         let mut pool = RawPool::new(len, shm).expect("failed to create RawPool");
         let released = Arc::new(AtomicBool::new(true));
         let buffers = vec![Buffer::new(
@@ -49,7 +49,7 @@ impl BumpPool {
                 0,
                 width,
                 height,
-                width * 4,
+                width * crate::pixel_format().channels() as i32,
                 crate::wl_shm_format(),
                 released.clone(),
                 qh,
@@ -68,7 +68,7 @@ impl BumpPool {
 
     #[inline]
     fn buffer_len(&self) -> usize {
-        self.width as usize * self.height as usize * 4
+        self.width as usize * self.height as usize * crate::pixel_format().channels() as usize
     }
 
     #[inline]
@@ -95,7 +95,7 @@ impl BumpPool {
                 self.buffer_offset(new_buffer_index).try_into().unwrap(),
                 self.width,
                 self.height,
-                self.width * 4,
+                self.width * crate::pixel_format().channels() as i32,
                 crate::wl_shm_format(),
                 released.clone(),
                 qh,
@@ -161,7 +161,7 @@ impl BumpPool {
                 0,
                 width,
                 height,
-                width * 4,
+                width * crate::pixel_format().channels() as i32,
                 crate::wl_shm_format(),
                 released.clone(),
                 qh,

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -104,6 +104,7 @@ extern "C" fn signal_handler(_s: i32) {
 fn main() -> Result<(), String> {
     rayon::ThreadPoolBuilder::default()
         .thread_name(|i| format!("rayon thread {i}"))
+        .stack_size(1 << 18) // 256KiB; we do not need a large stack
         .build_global()
         .expect("failed to configure rayon global thread pool");
     make_logger();

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -76,22 +76,22 @@ static PIXEL_FORMAT: OnceLock<PixelFormat> = OnceLock::new();
 #[inline]
 pub fn wl_shm_format() -> wl_shm::Format {
     debug_assert!(WL_SHM_FORMAT.get().is_some());
-    // SAFETY: this is safe because we initialize it in Daemon::new, before we ever call this in
-    // the wallpaper structs
-    *unsafe { WL_SHM_FORMAT.get().unwrap_unchecked() }
+    *WL_SHM_FORMAT.get().unwrap_or(&wl_shm::Format::Xrgb8888)
 }
 
 #[inline]
 pub fn pixel_format() -> PixelFormat {
     debug_assert!(PIXEL_FORMAT.get().is_some());
-    // SAFETY: this is safe because we initialize it in Daemon::new, before we ever call this in
-    // the wallpaper structs
-    *unsafe { PIXEL_FORMAT.get().unwrap_unchecked() }
+    *PIXEL_FORMAT.get().unwrap_or(&PixelFormat::Xrgb)
 }
 
 #[inline]
 pub fn wake_poll() {
     debug_assert!(POLL_WAKER.get().is_some());
+
+    // SAFETY: POLL_WAKER is set up in setup_signals_and_pipe, which is called early in main
+    // and panics if it fails. By the time anyone calls this function, POLL_WAKER will certainly
+    // already have been initialized.
     if let Err(e) = nix::unistd::write(*unsafe { POLL_WAKER.get().unwrap_unchecked() }, &[0]) {
         error!("failed to write to pipe file descriptor: {e}");
     }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -575,29 +575,27 @@ impl Dispatch<WlShm, GlobalData> for Daemon {
         _qhandle: &QueueHandle<Self>,
     ) {
         match event {
-            wl_shm::Event::Format { format: wenum } => {
-                match wenum {
-                    wayland_client::WEnum::Value(format) => {
-                        //if format == wl_shm::Format::Bgr888 {
-                        //    shm_format = wl_shm::Format::Bgr888;
-                        //    pixel_format = PixelFormat::Brg;
-                        //    break;
-                        //} else if format == wl_shm::Format::Rgb888 {
-                        //    shm_format = wl_shm::Format::Rgb888;
-                        //    pixel_format = PixelFormat::Rgb;
-                        /*} else*/
-                        if format == wl_shm::Format::Xbgr8888
-                            && state.pixel_format == PixelFormat::Xrgb
-                        {
-                            state.shm_format = wl_shm::Format::Xbgr8888;
-                            state.pixel_format = PixelFormat::Xbgr;
-                        }
-                    }
-                    wayland_client::WEnum::Unknown(v) => {
-                        error!("Received unknown shm format number {v} from server")
+            wl_shm::Event::Format { format: wenum } => match wenum {
+                wayland_client::WEnum::Value(format) => {
+                    if format == wl_shm::Format::Bgr888 {
+                        state.shm_format = wl_shm::Format::Bgr888;
+                        state.pixel_format = PixelFormat::Brg;
+                    } else if format == wl_shm::Format::Rgb888
+                        && state.pixel_format != PixelFormat::Brg
+                    {
+                        state.shm_format = wl_shm::Format::Rgb888;
+                        state.pixel_format = PixelFormat::Rgb;
+                    } else if format == wl_shm::Format::Xbgr8888
+                        && state.pixel_format == PixelFormat::Xrgb
+                    {
+                        state.shm_format = wl_shm::Format::Xbgr8888;
+                        state.pixel_format = PixelFormat::Xbgr;
                     }
                 }
-            }
+                wayland_client::WEnum::Unknown(v) => {
+                    error!("Received unknown shm format number {v} from server")
+                }
+            },
             e => warn!("Unhandled WlShm event: {e:?}"),
         }
     }

--- a/daemon/src/wallpaper.rs
+++ b/daemon/src/wallpaper.rs
@@ -201,12 +201,16 @@ impl Wallpaper {
             .store(false, Ordering::Release);
     }
 
-    pub(super) fn clear(&self, color: [u8; 3]) {
+    pub(super) fn clear(&self, mut color: [u8; 3]) {
+        let pixel_format = super::pixel_format();
+
+        if pixel_format.must_swap_r_and_b_channels() {
+            color.swap(0, 2);
+        }
+
         self.canvas_change(|canvas| {
-            for pixel in canvas.chunks_exact_mut(4) {
-                pixel[2] = color[0];
-                pixel[1] = color[1];
-                pixel[0] = color[2];
+            for pixel in canvas.chunks_exact_mut(pixel_format.channels().into()) {
+                pixel[0..3].copy_from_slice(&color);
             }
         })
     }

--- a/src/imgproc.rs
+++ b/src/imgproc.rs
@@ -177,7 +177,7 @@ pub fn compress_frames(
         };
 
         if let Some(canvas) = canvas.as_ref() {
-            match compressor.compress(canvas, &img) {
+            match compressor.compress(canvas, &img, format) {
                 Some(bytes) => compressed_frames.push((bytes, duration)),
                 None => match compressed_frames.last_mut() {
                     Some(last) => last.1 += duration,
@@ -185,7 +185,7 @@ pub fn compress_frames(
                 },
             }
         } else {
-            match compressor.compress(&first_img, &img) {
+            match compressor.compress(&first_img, &img, format) {
                 Some(bytes) => compressed_frames.push((bytes, duration)),
                 None => first_duration += duration,
             }
@@ -195,7 +195,7 @@ pub fn compress_frames(
 
     //Add the first frame we got earlier:
     if let Some(canvas) = canvas.as_ref() {
-        match compressor.compress(canvas, &first_img) {
+        match compressor.compress(canvas, &first_img, format) {
             Some(bytes) => compressed_frames.push((bytes, first_duration)),
             None => match compressed_frames.last_mut() {
                 Some(last) => last.1 += first_duration,

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,7 @@ fn make_animation_request(
     for (dim, outputs) in dims.iter().zip(outputs) {
         //TODO: make cache work for all resize strategies
         if img.resize == ResizeStrategy::Crop {
-            match cache::load_animation_frames(&img.path, *dim) {
+            match cache::load_animation_frames(&img.path, *dim, pixel_format.de()) {
                 Ok(Some(animation)) => {
                     animations.push((animation, outputs.to_owned().into_boxed_slice()));
                     continue;
@@ -305,6 +305,7 @@ fn make_animation_request(
                 &img.fill_color,
             )?
             .into_boxed_slice(),
+            pixel_format: pixel_format.de(),
         };
         animations.push((animation, outputs.to_owned().into_boxed_slice()));
     }

--- a/utils/benches/compression.rs
+++ b/utils/benches/compression.rs
@@ -42,17 +42,27 @@ pub fn compression_and_decompression(c: &mut Criterion) {
     let mut compressor = Compressor::new();
     let mut comp = c.benchmark_group("compression");
     comp.bench_function("Full", |b| {
-        b.iter(|| black_box(compressor.compress(&prev, &cur).is_some()))
+        b.iter(|| {
+            black_box(
+                compressor
+                    .compress(&prev, &cur, utils::ipc::ArchivedPixelFormat::Xrgb)
+                    .is_some(),
+            )
+        })
     });
     comp.finish();
 
-    let mut decomp = c.benchmark_group("decompression");
-    let bitpack = compressor.compress(&prev, &cur).unwrap();
+    let mut decomp = c.benchmark_group("decompression 4 channels");
+    let bitpack = compressor
+        .compress(&prev, &cur, utils::ipc::ArchivedPixelFormat::Xrgb)
+        .unwrap();
     let mut canvas = buf_from(&prev);
 
     let mut decompressor = Decompressor::new();
     decomp.bench_function("Full", |b| {
-        b.iter(|| black_box(decompressor.decompress(&bitpack, &mut canvas)))
+        b.iter(|| {
+            black_box(decompressor.decompress(&bitpack, &mut canvas, utils::ipc::PixelFormat::Xrgb))
+        })
     });
 
     decomp.finish();

--- a/utils/src/compression/comp/mod.rs
+++ b/utils/src/compression/comp/mod.rs
@@ -112,8 +112,9 @@ pub(super) unsafe fn pack_bytes(cur: &[u8], goal: &[u8], v: &mut Vec<u8>) {
     }
 
     if !v.is_empty() {
-        // add one extra zero to prevent access out of bounds later during decompression
-        v.push(0)
+        // add two extra bytes to prevent access out of bounds later during decompression
+        v.push(0);
+        v.push(0);
     }
 }
 

--- a/utils/src/compression/comp/sse2.rs
+++ b/utils/src/compression/comp/sse2.rs
@@ -102,8 +102,9 @@ pub(super) unsafe fn pack_bytes(cur: &[u8], goal: &[u8], v: &mut Vec<u8>) {
     }
 
     if !v.is_empty() {
-        // add one extra zero to prevent access out of bounds later during decompression
-        v.push(0)
+        // add two extra bytes to prevent access out of bounds later during decompression
+        v.push(0);
+        v.push(0);
     }
 }
 

--- a/utils/src/compression/comp/sse2.rs
+++ b/utils/src/compression/comp/sse2.rs
@@ -110,7 +110,7 @@ pub(super) unsafe fn pack_bytes(cur: &[u8], goal: &[u8], v: &mut Vec<u8>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compression::unpack_bytes;
+    use crate::compression::unpack_bytes_4channels;
     use rand::prelude::random;
 
     #[test]
@@ -157,7 +157,7 @@ mod tests {
         unsafe { pack_bytes(&frame1, &frame2, &mut compressed) };
 
         let mut buf = buf_from(&frame1);
-        unpack_bytes(&mut buf, &compressed);
+        unpack_bytes_4channels(&mut buf, &compressed);
         for i in 0..2 {
             for j in 0..3 {
                 assert_eq!(
@@ -196,7 +196,7 @@ mod tests {
 
             let mut buf = buf_from(original.last().unwrap());
             for i in 0..20 {
-                unpack_bytes(&mut buf, &compressed[i]);
+                unpack_bytes_4channels(&mut buf, &compressed[i]);
                 let mut j = 0;
                 let mut l = 0;
                 while j < 3000 {
@@ -252,7 +252,7 @@ mod tests {
 
             let mut buf = buf_from(original.last().unwrap());
             for i in 0..20 {
-                unpack_bytes(&mut buf, &compressed[i]);
+                unpack_bytes_4channels(&mut buf, &compressed[i]);
                 let mut j = 0;
                 let mut l = 0;
                 while j < 3000 {

--- a/utils/src/compression/decomp/mod.rs
+++ b/utils/src/compression/decomp/mod.rs
@@ -8,6 +8,10 @@ pub(super) mod ssse3;
 /// buf must have the EXACT expected size by the BitPack
 #[inline(always)]
 pub(super) fn unpack_bytes_4channels(buf: &mut [u8], diff: &[u8]) {
+    assert!(
+        diff[diff.len() - 1] | diff[diff.len() - 2] == 0,
+        "Poorly formed BitPack"
+    );
     // use the most efficient implementation available:
     #[cfg(not(test))] // when testing, we want to use the specific implementation
     {
@@ -17,15 +21,14 @@ pub(super) fn unpack_bytes_4channels(buf: &mut [u8], diff: &[u8]) {
         }
     }
 
-    // The very final byte is just padding to let us read 4 bytes at once without going out of
-    // bounds
-    let len = diff.len() - 1;
+    // The final bytes are just padding to prevent us from going out of bounds
+    let len = diff.len() - 3;
     let buf_ptr = buf.as_mut_ptr();
     let diff_ptr = diff.as_ptr();
 
     let mut diff_idx = 0;
     let mut pix_idx = 0;
-    while diff_idx + 1 < len {
+    while diff_idx < len {
         while unsafe { diff_ptr.add(diff_idx).read() } == u8::MAX {
             pix_idx += u8::MAX as usize;
             diff_idx += 1;
@@ -41,14 +44,13 @@ pub(super) fn unpack_bytes_4channels(buf: &mut [u8], diff: &[u8]) {
         to_cpy += unsafe { diff_ptr.add(diff_idx).read() } as usize;
         diff_idx += 1;
 
+        assert!(
+            diff_idx + to_cpy * 3 + 1 < diff.len(),
+            "copying: {}, diff.len(): {}",
+            diff_idx + to_cpy * 3 + 1,
+            diff.len()
+        );
         for _ in 0..to_cpy {
-            // it is much faster to use this assertion for testing than miri
-            debug_assert!(
-                diff_idx + 3 < diff.len(),
-                "diff_idx + 3: {}, diff.len(): {}",
-                diff_idx + 3,
-                diff.len()
-            );
             unsafe {
                 std::ptr::copy_nonoverlapping(diff_ptr.add(diff_idx), buf_ptr.add(pix_idx * 4), 4)
             }
@@ -61,15 +63,18 @@ pub(super) fn unpack_bytes_4channels(buf: &mut [u8], diff: &[u8]) {
 
 #[inline(always)]
 pub(super) fn unpack_bytes_3channels(buf: &mut [u8], diff: &[u8]) {
-    // The very final byte is just padding to let us read 4 bytes at once without going out of
-    // bounds
-    let len = diff.len() - 1;
+    assert!(
+        diff[diff.len() - 1] | diff[diff.len() - 2] == 0,
+        "Poorly formed BitPack"
+    );
+    // The final bytes are just padding to prevent us from going out of bounds
+    let len = diff.len() - 3;
     let buf_ptr = buf.as_mut_ptr();
     let diff_ptr = diff.as_ptr();
 
     let mut diff_idx = 0;
     let mut pix_idx = 0;
-    while diff_idx + 1 < len {
+    while diff_idx < len {
         while unsafe { diff_ptr.add(diff_idx).read() } == u8::MAX {
             pix_idx += u8::MAX as usize;
             diff_idx += 1;
@@ -85,9 +90,9 @@ pub(super) fn unpack_bytes_3channels(buf: &mut [u8], diff: &[u8]) {
         to_cpy += unsafe { diff_ptr.add(diff_idx).read() } as usize;
         diff_idx += 1;
 
-        debug_assert!(
+        assert!(
             diff_idx + to_cpy * 3 <= diff.len(),
-            "diff_idx: {diff_idx}, to_copy: {to_cpy} diff.len(): {}",
+            "diff_idx: {diff_idx}, to_copy: {to_cpy}, diff.len(): {}",
             diff.len()
         );
         unsafe {
@@ -99,5 +104,68 @@ pub(super) fn unpack_bytes_3channels(buf: &mut [u8], diff: &[u8]) {
         }
         diff_idx += to_cpy * 3;
         pix_idx += to_cpy + 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn ub_unpack_bytes4_poorly_formed() {
+        let mut bytes = vec![u8::MAX; 9];
+        let diff = vec![u8::MAX; 18];
+        unpack_bytes_4channels(&mut bytes, &diff);
+    }
+
+    #[test]
+    #[should_panic]
+    fn ub_unpack_bytes3_poorly_formed() {
+        let mut bytes = vec![u8::MAX; 9];
+        let diff = vec![u8::MAX; 18];
+        unpack_bytes_3channels(&mut bytes, &diff);
+    }
+
+    #[test]
+    #[should_panic]
+    fn ub_unpack_bytes4_poorly_formed2() {
+        let mut bytes = vec![u8::MAX; 9];
+        let mut diff = vec![u8::MAX; 18];
+        diff[8] = 0;
+        diff[7] = 0;
+        unpack_bytes_4channels(&mut bytes, &diff);
+    }
+
+    #[test]
+    #[should_panic]
+    fn ub_unpack_bytes3_poorly_formed2() {
+        let mut bytes = vec![u8::MAX; 9];
+        let mut diff = vec![u8::MAX; 18];
+        diff[8] = 0;
+        diff[7] = 0;
+        unpack_bytes_3channels(&mut bytes, &diff);
+    }
+
+    #[test]
+    #[should_panic]
+    fn ub_unpack_bytes4_poorly_formed3() {
+        let mut bytes = vec![u8::MAX; 9];
+        let mut diff = vec![u8::MAX; 18];
+        diff[8] = 0;
+        diff[7] = 0;
+        diff[2] = 0;
+        unpack_bytes_4channels(&mut bytes, &diff);
+    }
+
+    #[test]
+    #[should_panic]
+    fn ub_unpack_bytes3_poorly_formed3() {
+        let mut bytes = vec![u8::MAX; 9];
+        let mut diff = vec![u8::MAX; 18];
+        diff[8] = 0;
+        diff[7] = 0;
+        diff[2] = 0;
+        unpack_bytes_3channels(&mut bytes, &diff);
     }
 }

--- a/utils/src/compression/decomp/ssse3.rs
+++ b/utils/src/compression/decomp/ssse3.rs
@@ -1,6 +1,6 @@
 #[inline]
 #[target_feature(enable = "ssse3")]
-pub(super) unsafe fn unpack_bytes(buf: &mut [u8], diff: &[u8]) {
+pub(super) unsafe fn unpack_bytes_4channels(buf: &mut [u8], diff: &[u8]) {
     use std::arch::x86_64 as intr;
 
     // The very final byte is just padding to let us read 4 bytes at once without going out of
@@ -78,7 +78,7 @@ mod tests {
         unsafe { pack_bytes(&frame1, &frame2, &mut compressed) }
 
         let mut buf = buf_from(&frame1);
-        unsafe { unpack_bytes(&mut buf, &compressed) }
+        unsafe { unpack_bytes_4channels(&mut buf, &compressed) }
         for i in 0..2 {
             for j in 0..3 {
                 assert_eq!(
@@ -117,7 +117,7 @@ mod tests {
 
             let mut buf = buf_from(original.last().unwrap());
             for i in 0..20 {
-                unsafe { unpack_bytes(&mut buf, &compressed[i]) }
+                unsafe { unpack_bytes_4channels(&mut buf, &compressed[i]) }
                 let mut j = 0;
                 let mut l = 0;
                 while j < 3000 {
@@ -172,7 +172,7 @@ mod tests {
 
             let mut buf = buf_from(original.last().unwrap());
             for i in 0..20 {
-                unsafe { unpack_bytes(&mut buf, &compressed[i]) }
+                unsafe { unpack_bytes_4channels(&mut buf, &compressed[i]) }
                 let mut j = 0;
                 let mut l = 0;
                 while j < 3000 {

--- a/utils/src/compression/decomp/ssse3.rs
+++ b/utils/src/compression/decomp/ssse3.rs
@@ -3,16 +3,15 @@
 pub(super) unsafe fn unpack_bytes_4channels(buf: &mut [u8], diff: &[u8]) {
     use std::arch::x86_64 as intr;
 
-    // The very final byte is just padding to let us read 4 bytes at once without going out of
-    // bounds
-    let len = diff.len() - 1;
+    // The final bytes are just padding to prevent us from going out of bounds
+    let len = diff.len() - 3;
     let buf_ptr = buf.as_mut_ptr();
     let diff_ptr = diff.as_ptr();
     let mask = intr::_mm_set_epi8(-1, 11, 10, 9, -1, 8, 7, 6, -1, 5, 4, 3, -1, 2, 1, 0);
 
     let mut diff_idx = 0;
     let mut pix_idx = 0;
-    while diff_idx + 1 < len {
+    while diff_idx < len {
         while diff_ptr.add(diff_idx).read() == u8::MAX {
             pix_idx += u8::MAX as usize;
             diff_idx += 1;
@@ -28,6 +27,12 @@ pub(super) unsafe fn unpack_bytes_4channels(buf: &mut [u8], diff: &[u8]) {
         to_cpy += diff_ptr.add(diff_idx).read() as usize;
         diff_idx += 1;
 
+        assert!(
+            diff_idx + to_cpy * 3 + 1 < diff.len(),
+            "copying: {}, diff.len(): {}",
+            diff_idx + to_cpy * 3 + 1,
+            diff.len()
+        );
         while to_cpy > 4 {
             let d = intr::_mm_loadu_si128(diff_ptr.add(diff_idx).cast());
             let to_store = intr::_mm_shuffle_epi8(d, mask);
@@ -38,12 +43,6 @@ pub(super) unsafe fn unpack_bytes_4channels(buf: &mut [u8], diff: &[u8]) {
             to_cpy -= 4;
         }
         for _ in 0..to_cpy {
-            debug_assert!(
-                diff_idx + 3 < diff.len(),
-                "diff_idx + 3: {}, diff.len(): {}",
-                diff_idx + 3,
-                diff.len()
-            );
             std::ptr::copy_nonoverlapping(diff_ptr.add(diff_idx), buf_ptr.add(pix_idx * 4), 4);
             diff_idx += 3;
             pix_idx += 1;

--- a/utils/src/ipc.rs
+++ b/utils/src/ipc.rs
@@ -138,15 +138,67 @@ impl fmt::Display for ArchivedBgImg {
     }
 }
 
+#[derive(Clone, Copy, Archive, Serialize, PartialEq)]
+#[archive_attr(derive(Clone, Copy))]
+pub enum PixelFormat {
+    /// No swap, can copy directly onto WlBuffer
+    Brg,
+    /// Swap R and B channels at client, can copy directly onto WlBuffer
+    Rgb,
+    /// No swap, must extend pixel with an extra byte when copying
+    Xbgr,
+    /// Swap R and B channels at client, must extend pixel with an extra byte when copying
+    Xrgb,
+}
+
+impl PixelFormat {
+    #[inline]
+    #[must_use]
+    pub fn channels(&self) -> u8 {
+        match self {
+            Self::Rgb => 3,
+            Self::Brg => 3,
+            Self::Xbgr => 4,
+            Self::Xrgb => 4,
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn can_copy_directly_onto_wl_buffer(&self) -> bool {
+        match self {
+            Self::Brg => true,
+            Self::Rgb => true,
+            Self::Xbgr => false,
+            Self::Xrgb => false,
+        }
+    }
+}
+
+impl ArchivedPixelFormat {
+    #[inline]
+    #[must_use]
+    pub fn must_swap_r_and_b_channels(&self) -> bool {
+        match self {
+            Self::Brg => false,
+            Self::Rgb => true,
+            Self::Xbgr => false,
+            Self::Xrgb => true,
+        }
+    }
+}
+
 #[derive(Clone, Archive, Serialize)]
 pub struct BgInfo {
     pub name: String,
     pub dim: (u32, u32),
     pub scale_factor: i32,
     pub img: BgImg,
+    pub pixel_format: PixelFormat,
 }
 
 impl BgInfo {
+    #[inline]
     #[must_use]
     pub fn real_dim(&self) -> (u32, u32) {
         (


### PR DESCRIPTION
Using `Format::Bgr888` or `Format::Rgb888` when they are available result in memory savings (since our buffers have 3/4 the size) and slight performance improvements, because we don't have to swap the R and B channels.

This PR increases the code base's complexity somewhat. It might be worth it to spend some trying to make things clearer and/or simpler in general.