### PR TITLE
option to force use of a wayland_shm format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,14 @@ edition = "2021"
 # we use `std::cell::OnceLock` which was stabilized in 1.70
 rust-version = "1.70"
 
+# Enable some optimizations in debug mode. Otherwise, it is a pain to test it
+[profile.dev]
+opt-level = 1
+
+# Enable high optimizations for dependencies, but not for our code:
+[profile.dev.package."*"]
+opt-level = 3
+
 [profile.release]
 debug = 0
 lto = true

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -102,6 +102,39 @@ extern "C" fn signal_handler(_s: i32) {
 }
 
 fn main() -> Result<(), String> {
+    let mut args = std::env::args();
+    let _ = args.next();
+    if let Some(arg) = args.next() {
+        if arg != "--format" {
+            return Err(format!("Unrecognized command line argument: {arg}"));
+        }
+
+        match args.next().as_deref() {
+            Some("xrgb") => {
+                PIXEL_FORMAT.set(PixelFormat::Xrgb).unwrap();
+                WL_SHM_FORMAT.set(wl_shm::Format::Xrgb8888).unwrap();
+            }
+            Some("xbgr") => {
+                PIXEL_FORMAT.set(PixelFormat::Xbgr).unwrap();
+                WL_SHM_FORMAT.set(wl_shm::Format::Xbgr8888).unwrap();
+            }
+            Some("rgb") => {
+                PIXEL_FORMAT.set(PixelFormat::Rgb).unwrap();
+                WL_SHM_FORMAT.set(wl_shm::Format::Rgb888).unwrap();
+            }
+            Some("bgr") => {
+                PIXEL_FORMAT.set(PixelFormat::Bgr).unwrap();
+                WL_SHM_FORMAT.set(wl_shm::Format::Bgr888).unwrap();
+            }
+            _ => {
+                return Err(
+                    "`--format` command line option must be one of: 'xrgb', 'xbgr', 'rgb' or 'bgr'"
+                        .to_string(),
+                )
+            }
+        }
+    }
+
     rayon::ThreadPoolBuilder::default()
         .thread_name(|i| format!("rayon thread {i}"))
         .stack_size(1 << 18) // 256KiB; we do not need a large stack
@@ -580,9 +613,9 @@ impl Dispatch<WlShm, GlobalData> for Daemon {
                 wayland_client::WEnum::Value(format) => {
                     if format == wl_shm::Format::Bgr888 {
                         state.shm_format = wl_shm::Format::Bgr888;
-                        state.pixel_format = PixelFormat::Brg;
+                        state.pixel_format = PixelFormat::Bgr;
                     } else if format == wl_shm::Format::Rgb888
-                        && state.pixel_format != PixelFormat::Brg
+                        && state.pixel_format != PixelFormat::Bgr
                     {
                         state.shm_format = wl_shm::Format::Rgb888;
                         state.pixel_format = PixelFormat::Rgb;

--- a/doc/swww-init.1.scd
+++ b/doc/swww-init.1.scd
@@ -16,10 +16,19 @@ swww-init
 	much (ideally). This is mostly useful for debugging and developing.
 
 *--no-cache*
-	Don't load the cache *during initialization* (it still loads on monitor (re)connection)
+	Don't load the cache *during initialization* (it still loads on monitor
+	(re)connection).
 
 	If want to always pass an image for `swww` to load, this option can help make the
 	results some reliable: `swww init --no-cache && swww img <some img>`
+
+*--format* <xrgb|xbgr|rgb|bgr>
+	Force the daemon to use a specific wl_shm format.
+	
+	IMPORTANT: make sure this is a value your compositor actually supports!
+	`swww-daemon` will automatically select the best format for itself during
+	initialization; this is only here for fallback, debug, and workaround
+	purposes.
 
 *-h*, *--help*
 	Print help (see a summary with '-h')

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,18 @@ fn from_hex(hex: &str) -> Result<[u8; 3], String> {
     Ok(color)
 }
 
+#[derive(Clone, ValueEnum)]
+pub enum PixelFormat {
+    /// No swap, can copy directly onto WlBuffer
+    Bgr,
+    /// Swap R and B channels at client, can copy directly onto WlBuffer
+    Rgb,
+    /// No swap, must extend pixel with an extra byte when copying
+    Xbgr,
+    /// Swap R and B channels at client, must extend pixel with an extra byte when copying
+    Xrgb,
+}
+
 #[derive(Clone)]
 pub enum Filter {
     Nearest,
@@ -173,6 +185,14 @@ pub enum Swww {
         ///results some reliable: `swww init --no-cache && swww img <some img>`
         #[clap(long)]
         no_cache: bool,
+
+        /// Force the daemon to use a specific wl_shm format
+        ///
+        /// IMPORTANT: make sure this is a value your compositor actually supports! `swww` will
+        /// automatically select the best format for itself during initialization; this is only
+        /// here for fallback, debug, and workaround purposes
+        #[clap(long)]
+        format: PixelFormat,
     },
 
     ///Kills the daemon

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -192,7 +192,7 @@ pub enum Swww {
         /// automatically select the best format for itself during initialization; this is only
         /// here for fallback, debug, and workaround purposes
         #[clap(long)]
-        format: PixelFormat,
+        format: Option<PixelFormat>,
     },
 
     ///Kills the daemon

--- a/utils/src/ipc.rs
+++ b/utils/src/ipc.rs
@@ -142,7 +142,7 @@ impl fmt::Display for ArchivedBgImg {
 #[archive_attr(derive(Clone, Copy, Debug))]
 pub enum PixelFormat {
     /// No swap, can copy directly onto WlBuffer
-    Brg,
+    Bgr,
     /// Swap R and B channels at client, can copy directly onto WlBuffer
     Rgb,
     /// No swap, must extend pixel with an extra byte when copying
@@ -157,7 +157,7 @@ impl PixelFormat {
     pub const fn channels(&self) -> u8 {
         match self {
             Self::Rgb => 3,
-            Self::Brg => 3,
+            Self::Bgr => 3,
             Self::Xbgr => 4,
             Self::Xrgb => 4,
         }
@@ -167,7 +167,7 @@ impl PixelFormat {
     #[must_use]
     pub const fn must_swap_r_and_b_channels(&self) -> bool {
         match self {
-            Self::Brg => false,
+            Self::Bgr => false,
             Self::Rgb => true,
             Self::Xbgr => false,
             Self::Xrgb => true,
@@ -178,7 +178,7 @@ impl PixelFormat {
     #[must_use]
     pub const fn can_copy_directly_onto_wl_buffer(&self) -> bool {
         match self {
-            Self::Brg => true,
+            Self::Bgr => true,
             Self::Rgb => true,
             Self::Xbgr => false,
             Self::Xrgb => false,
@@ -192,7 +192,7 @@ impl ArchivedPixelFormat {
     pub const fn channels(&self) -> u8 {
         match self {
             Self::Rgb => 3,
-            Self::Brg => 3,
+            Self::Bgr => 3,
             Self::Xbgr => 4,
             Self::Xrgb => 4,
         }
@@ -202,7 +202,7 @@ impl ArchivedPixelFormat {
     #[must_use]
     pub const fn must_swap_r_and_b_channels(&self) -> bool {
         match self {
-            Self::Brg => false,
+            Self::Bgr => false,
             Self::Rgb => true,
             Self::Xbgr => false,
             Self::Xrgb => true,


### PR DESCRIPTION
This should aid in debugging and serve as a workaround if there's something wrong with the non-default formats.

This is intended as a workaround for #233. 