### PR TITLE
Deprecate swww init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 MSRV is now 1.74.0.
 
+#### Deprecated
+
+`swww init` is now considered deprecated. Use `swww-daemon` instead. To run it
+in the background, simply do `swww-daemon &`.
+
 #### Fixes
 
   * fix the `let_underscore_lock` error. Note that all 0.8.* will probably no
@@ -35,7 +40,8 @@ MSRV is now 1.74.0.
   improvements. Unfortunately, it seems to not work for some people on some
   notebooks (see [Known Issues](#known-issues)).
   * Implemented a way to force the use of a specific wayland_shm format, as a
-  workaround for [Known Issues](#known-issues).
+  workaround for [Known Issues](#known-issues). Also went ahead and implemented
+  some cli options for the daemon.
   * Support for animated pngs
   * Support for animations when piping images from standard input
   * Fps is now a `u16`, so we can support newest monitors framerates

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ makes switching from one image to the next to happen very abruptly.
 
 Start by initializing the daemon:
 ```
-swww init
+swww-daemon
 ```
-Then, simply pass the image you want to display:
+Then, in a different terminal, simply pass the image you want to display:
 ```
 swww img <path/to/img>
 

--- a/doc/swww-clear-cache.1.scd
+++ b/doc/swww-clear-cache.1.scd
@@ -21,7 +21,7 @@ those locations corresponding to the current image/animation being displayed.
 
 Furthermore,  the cache will keep preprocessed versions of `gif`s. So, if you
 load a large `gif`, you would have to pay the price for its processing the first
-time. 
+time.
 
 Note that `swww` will automatically delete any preprocessed animation created
 with a previous version of `swww` from the cache.

--- a/doc/swww-daemon.1.scd
+++ b/doc/swww-daemon.1.scd
@@ -3,34 +3,34 @@ swww-daemon(1)
 # NAME
 swww-daemon
 
-# DESCRIPTION 
+# SYNOPSIS
+swww-daemon [-q|--quiet] [-f|--format <xrgb|xbgr|rgb|bgr>]
+
+# OPTIONS
+
+*-f*,*--format* <xrgb|xbgr|rgb|bgr>
+	Force the daemon to use a specific wl_shm format.
+
+	IMPORTANT: make sure this is a value your compositor actually supports!
+	'swww-daemon' will automatically select the best format for itself during
+	initialization; this is only here for fallback, debug, and workaround
+	purposes.
+
+*-q*,*--quiet*
+	Makes the daemon only log errors.
+
+*-h*, *--help*
+	Print help (see a summary with '-h')
+
+*-V*, *--version*
+	Print version
+
+# DESCRIPTION
 
 The *swww-daemon* will run continuously, waiting for commands in
-_$XDG_RUNTIME_DIR/swww.socket_(or _/tmp/swww/swww.socket_, if $XDG_RUNTIME_DIR
+_$XDG_RUNTIME_DIR/swww.socket_ (or _/tmp/swww/swww.socket_, if $XDG_RUNTIME_DIR
 is not set). The daemon will take care of both creating and deleting that file
 when it is initialized or killed.
-
-*There is no reason for you to run the swww-daemon manually*. The daemon should
-be started through *swww init* and killed through *swww kill*. Running the
-daemon manually would only help for debugging, or developing *swww*. *swww init*
-has the benefits that it checks to see if another instance is already running,
-and it waits for the daemon to be ready, so something like
-
-```
-swww init && swww img bg.png
-```
-
-works, but 
-
-```
-swww-daemon &
-swww img bg.png
-```
-
-*can potentially fail*, because the daemon might still not be ready by the time
-the client sends the image.
-
-Bottom line is: just use *swww init* to initialize the daemon.
 
 # SEE ALSO
 *swww-init*(1)

--- a/doc/swww-img.1.scd
+++ b/doc/swww-img.1.scd
@@ -38,7 +38,7 @@ swww-img
 
 *--resize* <RESIZE>
 	Whether to resize the image and the method by which to resize it.
-	
+
 	Possible values:
 		- _no_:   Do not resize the image
 		- _crop_: Resize the image to fill the whole screen, cropping out parts that don't fit
@@ -83,7 +83,7 @@ swww-img
 	_none_ is an alias to _simple_, that also sets the _transition-step_ to
 	255. This has the effect of the transition completing instantly.
 
-	_fade_ is like _simple_ but uses bezier curves while fading the image, its a 
+	_fade_ is like _simple_ but uses bezier curves while fading the image, its a
 	more polished looking version of _simple_ with less artifacts
 
 	The _left_, _right_, _top_ and _bottom_ options make the transition	happen
@@ -222,7 +222,7 @@ Importantly, **cache will only be loaded during initialization if you use swww
 init**. That is, calling `swww-daemon` directly will **NOT** load the cache, but
 calling `swww-init` will.
 
-The `swww-daemon` will actually wait until the first image has been set before 
+The `swww-daemon` will actually wait until the first image has been set before
 trying to load the cache.
 
 Finally, the cache will keep preprocessed versions of `gif`s. So, if you load a

--- a/doc/swww-init.1.scd
+++ b/doc/swww-init.1.scd
@@ -1,10 +1,10 @@
 swww-init(1)
 
 # NAME
-swww-init
+swww-init (DEPRECATED)
 
 # SYNOPSIS
-*swww init* [--no-daemon]
+*swww init* [--no-daemon] [--no-cache] [--format <xrgb|xbgr|rgb|bgr>]
 
 # OPTIONS
 
@@ -19,14 +19,14 @@ swww-init
 	Don't load the cache *during initialization* (it still loads on monitor
 	(re)connection).
 
-	If want to always pass an image for `swww` to load, this option can help make the
-	results some reliable: `swww init --no-cache && swww img <some img>`
+	If want to always pass an image for 'swww' to load, this option can help make the
+	results some reliable: 'swww init --no-cache && swww img <some img>'
 
 *--format* <xrgb|xbgr|rgb|bgr>
 	Force the daemon to use a specific wl_shm format.
-	
+
 	IMPORTANT: make sure this is a value your compositor actually supports!
-	`swww-daemon` will automatically select the best format for itself during
+	'swww-daemon' will automatically select the best format for itself during
 	initialization; this is only here for fallback, debug, and workaround
 	purposes.
 
@@ -35,9 +35,8 @@ swww-init
 
 # DESCRIPTION
 
-Initializes the daemon. This is the recommended way of doing it, since we make
-sure to check if another instance is already running, and wait until the daemon
-is 100% ready to receive requests.
+Initializes the daemon. This is used to be the recommended way of doing it, but
+that is no longer the case. You should call 'swww-daemon' directly instead.
 
 # SEE ALSO
 *swww-daemon*(1)

--- a/doc/swww-kill.1.scd
+++ b/doc/swww-kill.1.scd
@@ -11,7 +11,7 @@ swww-kill
 *-h*, *--help*
 	Print help (see a summary with '-h')
 
-# DESCRIPTION 
+# DESCRIPTION
 
 Kills the daemon. This is the recommended way of doing it, since we wait to make
 sure the socket file was deleted, thus confirming the daemon exited.

--- a/doc/swww-query.1.scd
+++ b/doc/swww-query.1.scd
@@ -11,7 +11,7 @@ swww-query
 *-h*, *--help*
 	Print help (see a summary with '-h')
 
-# DESCRIPTION 
+# DESCRIPTION
 
 Asks the daemon to print output information (names and dimensions).
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,9 @@ fn main() -> Result<(), String> {
         no_daemon, format, ..
     } = &swww
     {
+        eprintln!(
+            "DEPRECATION WARNING: `swww init` IS DEPRECATED. Call `swww-daemon` directly instead"
+        );
         match is_daemon_running() {
             Ok(false) => {
                 let socket_path = get_socket_path();

--- a/version.sh
+++ b/version.sh
@@ -24,7 +24,7 @@ mv -v TMP Cargo.toml
 sed "s/^version = .*/version = \"$1\"/" utils/Cargo.toml > TMP
 mv -v TMP utils/Cargo.toml
 
-sed "s/^version = .*/version = \"$1\"/" daemon/Cargo.toml > TM
+sed "s/^version = .*/version = \"$1\"/" daemon/Cargo.toml > TMP
 mv -v TMP daemon/Cargo.toml
 
 # CHANGELOG:


### PR DESCRIPTION
This is the first step towards #182. For the next `swww` version, we deprecate the `init` command. In the version following that we will remove it completely.