### PR TITLE
Fix build on i686 (32bit x86)

### DIFF
--- a/utils/src/compression/comp/sse2.rs
+++ b/utils/src/compression/comp/sse2.rs
@@ -4,6 +4,9 @@
 #[inline]
 #[target_feature(enable = "sse2")]
 unsafe fn count_equals(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86 as intr;
+    #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64 as intr;
     let mut equals = 0;
     while i + 15 < s1.len() {
@@ -39,6 +42,9 @@ unsafe fn count_equals(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
 #[inline]
 #[target_feature(enable = "sse2")]
 unsafe fn count_different(s1: &[u8], s2: &[u8], mut i: usize) -> usize {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86 as intr;
+    #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64 as intr;
     let mut diff = 0;
     while i + 15 < s1.len() {

--- a/utils/src/compression/cpu.rs
+++ b/utils/src/compression/cpu.rs
@@ -30,7 +30,7 @@ pub(super) fn init() {
     ONCE_INIT.call_once(|| unsafe { features::init() });
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub mod features {
     decl_feature!(SSE2, sse2);
     decl_feature!(SSSE3, ssse3);
@@ -49,7 +49,7 @@ pub mod features {
     }
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 pub mod features {
 
     /// UNIMPLEMENTED!!! This function must exist so that the init function in super compiles on

--- a/utils/src/compression/decomp/ssse3.rs
+++ b/utils/src/compression/decomp/ssse3.rs
@@ -1,6 +1,9 @@
 #[inline]
 #[target_feature(enable = "ssse3")]
 pub(super) unsafe fn unpack_bytes_4channels(buf: &mut [u8], diff: &[u8]) {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86 as intr;
+    #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64 as intr;
 
     // The final bytes are just padding to prevent us from going out of bounds


### PR DESCRIPTION
The build was failing in i686 (32bit x86) because the module `std::arch::x86_64` is only available on x86_64. i686 needs to be detected, so that the module `std::arch::x86` is used instead.