### PR TITLE
Bitcode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,7 +97,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -134,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "av1-grain"
@@ -168,6 +157,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
+name = "bitcode"
+version = "0.6.0"
+source = "git+https://github.com/SoftbearStudios/bitcode.git?rev=5f25a59#5f25a59be3e66deef721e7eb2369deb1aa32d263"
+dependencies = [
+ "bitcode_derive",
+ "bytemuck",
+]
+
+[[package]]
+name = "bitcode_derive"
+version = "0.6.0"
+source = "git+https://github.com/SoftbearStudios/bitcode.git?rev=5f25a59#5f25a59be3e66deef721e7eb2369deb1aa32d263"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,18 +192,6 @@ name = "bitstream-io"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06c9989a51171e2e81038ab168b6ae22886fe9ded214430dbb4f41c28cf176da"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bstr"
@@ -221,28 +217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "bytemuck"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,12 +227,6 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "bytes"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cast"
@@ -327,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -359,14 +327,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -583,12 +551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,15 +583,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -648,9 +601,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "image"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b4f005360d32e9325029b38ba47ebd7a56f3316df09249368939562d518645"
+checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -692,7 +645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -703,7 +656,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -737,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
@@ -857,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memmap2"
@@ -951,7 +904,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1123,27 +1076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote",
- "syn 2.0.53",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1178,12 +1111,6 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1267,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -1287,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1310,18 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rgb"
@@ -1330,35 +1248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
 dependencies = [
  "bytemuck",
-]
-
-[[package]]
-name = "rkyv"
-version = "0.7.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1408,12 +1297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "621e3680f3e07db4c9c2c3fb07c6223ab2fab2e54bd3c04c3ae037990f428c32"
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "serde"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,14 +1313,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -1467,12 +1350,6 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simplelog"
@@ -1555,12 +1432,12 @@ dependencies = [
 name = "swww-daemon"
 version = "0.9.1-master"
 dependencies = [
+ "bitcode",
  "keyframe",
  "log",
  "nix",
  "rand",
  "rayon",
- "rkyv",
  "sd-notify",
  "simplelog",
  "smithay-client-toolkit",
@@ -1571,20 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1603,12 +1469,6 @@ dependencies = [
  "toml",
  "version-compare",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -1658,7 +1518,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1716,21 +1576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "toml"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,17 +1625,11 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 name = "utils"
 version = "0.9.1-master"
 dependencies = [
+ "bitcode",
  "criterion",
  "pkg-config",
  "rand",
- "rkyv",
 ]
-
-[[package]]
-name = "uuid"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "v_frame"
@@ -1808,12 +1647,6 @@ name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"
@@ -1861,7 +1694,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1883,7 +1716,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2176,15 +2009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/TODO
+++ b/TODO
@@ -3,9 +3,9 @@ Fully automated, complete testing, for every option
 	testing many things with different setups. Maybe we can script it somehow?
 
 Rewrite using rustix + signal_hook instead of nix.
+	- Take oportunity to use shared memory instead of unix sockets
 
-Do not use a pipe as a way of waking up the main thread in the daemon. A simple
-fd should do.
+Rewrite IPC using bitcode
 
 Nuke smithay-client-toolkit
 	- copy over their implementation of RawPool (see if we can improve it for

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -13,9 +13,10 @@ simplelog = "0.12"
 wayland-client = { version = "0.31", default-features = false, features = [ "log" ]}
 smithay-client-toolkit = { version = "0.18", default-features = false }
 
+# use specific git version for Duration implementation. We will do this until the next bitcode release
+bitcode = { git = "https://github.com/SoftbearStudios/bitcode.git", rev = "5f25a59", default-features = false }
 nix = { version = "0.28", default-features = false, features = [ "signal", "poll", "event" ] }
 keyframe = "1.1"
-rkyv = "0.7"
 rayon = "1.9"
 spin_sleep = "1.2"
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -13,7 +13,7 @@ simplelog = "0.12"
 wayland-client = { version = "0.31", default-features = false, features = [ "log" ]}
 smithay-client-toolkit = { version = "0.18", default-features = false }
 
-nix = { version = "0.28", default-features = false, features = [ "signal", "poll" ] }
+nix = { version = "0.28", default-features = false, features = [ "signal", "poll", "event" ] }
 keyframe = "1.1"
 rkyv = "0.7"
 rayon = "1.9"

--- a/daemon/src/animations/transitions.rs
+++ b/daemon/src/animations/transitions.rs
@@ -6,7 +6,7 @@ use std::{
 use rayon::prelude::*;
 
 use log::debug;
-use utils::ipc::{ArchivedPosition, ArchivedTransitionType};
+use utils::ipc::{Position, TransitionType};
 
 use crate::wallpaper::{AnimationToken, Wallpaper};
 
@@ -18,12 +18,12 @@ pub(super) struct Transition {
     animation_tokens: Vec<AnimationToken>,
     wallpapers: Vec<Arc<Wallpaper>>,
     dimensions: (u32, u32),
-    transition_type: ArchivedTransitionType,
+    transition_type: TransitionType,
     duration: f32,
     step: u8,
     fps: Duration,
     angle: f64,
-    pos: ArchivedPosition,
+    pos: Position,
     bezier: BezierCurve,
     wave: (f32, f32),
     invert_y: bool,
@@ -34,7 +34,7 @@ impl Transition {
     pub(super) fn new(
         wallpapers: Vec<Arc<Wallpaper>>,
         dimensions: (u32, u32),
-        transition: &utils::ipc::ArchivedTransition,
+        transition: &utils::ipc::Transition,
     ) -> Self {
         Transition {
             animation_tokens: wallpapers
@@ -43,7 +43,7 @@ impl Transition {
                 .collect(),
             wallpapers,
             dimensions,
-            transition_type: transition.transition_type.clone(),
+            transition_type: transition.transition_type,
             duration: transition.duration,
             step: transition.step,
             fps: Duration::from_nanos(1_000_000_000 / transition.fps as u64),
@@ -67,12 +67,12 @@ impl Transition {
     pub(super) fn execute(mut self, new_img: &[u8]) {
         debug!("Starting transitions");
         match self.transition_type {
-            ArchivedTransitionType::Simple => self.simple(new_img),
-            ArchivedTransitionType::Wipe => self.wipe(new_img),
-            ArchivedTransitionType::Grow => self.grow(new_img),
-            ArchivedTransitionType::Outer => self.outer(new_img),
-            ArchivedTransitionType::Wave => self.wave(new_img),
-            ArchivedTransitionType::Fade => self.fade(new_img),
+            TransitionType::Simple => self.simple(new_img),
+            TransitionType::Wipe => self.wipe(new_img),
+            TransitionType::Grow => self.grow(new_img),
+            TransitionType::Outer => self.outer(new_img),
+            TransitionType::Wave => self.wave(new_img),
+            TransitionType::Fade => self.fade(new_img),
         };
         debug!("Transitions finished");
         for (wallpaper, token) in self.wallpapers.iter().zip(self.animation_tokens) {

--- a/deny.toml
+++ b/deny.toml
@@ -29,4 +29,4 @@ allow = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["https://github.com/SoftbearStudios/bitcode.git"]

--- a/src/imgproc.rs
+++ b/src/imgproc.rs
@@ -12,7 +12,7 @@ use std::{
 
 use utils::{
     compression::{BitPack, Compressor},
-    ipc::{self, ArchivedPixelFormat, Coord, Position},
+    ipc::{self, Coord, PixelFormat, Position},
 };
 
 use crate::cli::ResizeStrategy;
@@ -69,7 +69,7 @@ impl ImgBuf {
     }
 
     /// Decode the ImgBuf into am RgbImage
-    pub fn decode(&self, format: ArchivedPixelFormat) -> Result<Image, String> {
+    pub fn decode(&self, format: PixelFormat) -> Result<Image, String> {
         let mut reader = image::io::Reader::new(Cursor::new(&self.bytes));
         reader.set_format(self.format);
         let dynimage = reader
@@ -128,7 +128,7 @@ impl ImgBuf {
 pub struct Image {
     width: u32,
     height: u32,
-    format: ArchivedPixelFormat,
+    format: PixelFormat,
     bytes: Box<[u8]>,
 }
 
@@ -160,15 +160,15 @@ impl Image {
         }
     }
 
-    fn from_frame(frame: image::Frame, format: ArchivedPixelFormat) -> Self {
+    fn from_frame(frame: image::Frame, format: PixelFormat) -> Self {
         let dynimage = DynamicImage::ImageRgba8(frame.into_buffer());
         let (width, height) = dynimage.dimensions();
 
         // NOTE: when animating frames, we ALWAYS use 3 channels
 
         let format = match format {
-            ArchivedPixelFormat::Bgr | ArchivedPixelFormat::Xbgr => ArchivedPixelFormat::Bgr,
-            ArchivedPixelFormat::Rgb | ArchivedPixelFormat::Xrgb => ArchivedPixelFormat::Rgb,
+            PixelFormat::Bgr | PixelFormat::Xbgr => PixelFormat::Bgr,
+            PixelFormat::Rgb | PixelFormat::Xrgb => PixelFormat::Rgb,
         };
 
         let mut bytes = dynimage.into_rgb8().into_raw().into_boxed_slice();
@@ -190,7 +190,7 @@ impl Image {
 pub fn compress_frames(
     mut frames: Frames,
     dim: (u32, u32),
-    format: ArchivedPixelFormat,
+    format: PixelFormat,
     filter: FilterType,
     resize: ResizeStrategy,
     color: &[u8; 3],

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-rkyv = "0.7"
+# use specific git version for Duration implementation. We will do this until the next bitcode release
+bitcode = { git = "https://github.com/SoftbearStudios/bitcode.git", rev = "5f25a59", default-features = false, features = [ "derive" ]}
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/utils/benches/compression.rs
+++ b/utils/benches/compression.rs
@@ -45,7 +45,7 @@ pub fn compression_and_decompression(c: &mut Criterion) {
         b.iter(|| {
             black_box(
                 compressor
-                    .compress(&prev, &cur, utils::ipc::ArchivedPixelFormat::Xrgb)
+                    .compress(&prev, &cur, utils::ipc::PixelFormat::Xrgb)
                     .is_some(),
             )
         })
@@ -54,7 +54,7 @@ pub fn compression_and_decompression(c: &mut Criterion) {
 
     let mut decomp = c.benchmark_group("decompression 4 channels");
     let bitpack = compressor
-        .compress(&prev, &cur, utils::ipc::ArchivedPixelFormat::Xrgb)
+        .compress(&prev, &cur, utils::ipc::PixelFormat::Xrgb)
         .unwrap();
     let mut canvas = buf_from(&prev);
 


### PR DESCRIPTION
Use `bitcode` instead of `rkyv` for serialization. Bitcode serializes faster, and because we actually deserialize in the `daemon`, we need to do less bending over backwards with different types and references (no need to use ArchivedStruct anymore).