### PR TITLE
Nix -> rustix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,12 +261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,18 +846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.5.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,10 +1416,11 @@ version = "0.9.1-master"
 dependencies = [
  "bitcode",
  "keyframe",
+ "libc",
  "log",
- "nix",
  "rand",
  "rayon",
+ "rustix",
  "sd-notify",
  "simplelog",
  "smithay-client-toolkit",

--- a/TODO
+++ b/TODO
@@ -2,11 +2,6 @@ Fully automated, complete testing, for every option
 	This is annoying because it would involve changing the output scaling and
 	testing many things with different setups. Maybe we can script it somehow?
 
-Rewrite using rustix + signal_hook instead of nix.
-	- Take oportunity to use shared memory instead of unix sockets
-
-Rewrite IPC using bitcode
-
 Nuke smithay-client-toolkit
 	- copy over their implementation of RawPool (see if we can improve it for
 	our purposes)

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -15,7 +15,9 @@ smithay-client-toolkit = { version = "0.18", default-features = false }
 
 # use specific git version for Duration implementation. We will do this until the next bitcode release
 bitcode = { git = "https://github.com/SoftbearStudios/bitcode.git", rev = "5f25a59", default-features = false }
-nix = { version = "0.28", default-features = false, features = [ "signal", "poll", "event" ] }
+rustix = { version = "0.38", default-features = false, features = [ "event" ] }
+libc = "0.2"
+
 keyframe = "1.1"
 rayon = "1.9"
 spin_sleep = "1.2"


### PR DESCRIPTION
We nuke `nix` in favor of the `rustix` crate. It is more actively maintained, and should be somewhat more performant as well.