### PR TITLE
Add support for running on multiple Wayland displays simultaneously.

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -735,9 +735,7 @@ fn make_logger(quiet: bool) {
 }
 
 fn find_fd_number(addr: &PathBuf) -> Result<u64, String> {
-    let proc = std::path::PathBuf::from("/proc");
-    let mut sockets = proc.clone();
-    sockets.push("net/unix");
+    let sockets = std::path::PathBuf::from("/proc/net/unix");
 
     let file = match std::fs::File::open(sockets) {
         Ok(f) => f,

--- a/utils/src/ipc.rs
+++ b/utils/src/ipc.rs
@@ -3,7 +3,7 @@ use std::{
     fmt,
     io::{BufReader, BufWriter, Read, Write},
     os::unix::net::UnixStream,
-    path::{Path, PathBuf},
+    path::PathBuf,
     time::Duration,
 };
 
@@ -328,8 +328,22 @@ pub fn get_socket_path() -> PathBuf {
     } else {
         "/tmp/swww".to_string()
     };
-    let runtime_dir = Path::new(&runtime_dir);
-    runtime_dir.join("swww.socket")
+
+    let mut socket_path = PathBuf::new();
+    socket_path.push(runtime_dir);
+
+    let mut socket_name = String::new();
+    socket_name.push_str("swww-");
+    if let Ok(socket) = std::env::var("WAYLAND_DISPLAY") {
+        socket_name.push_str(socket.as_str());
+    } else {
+        socket_name.push_str("wayland-0")
+    }
+    socket_name.push_str(".socket");
+
+    socket_path.push(socket_name);
+
+    socket_path
 }
 
 pub fn get_cache_path() -> Result<PathBuf, String> {


### PR DESCRIPTION
This changes the socket that ``swww`` listens to to ``/run/user/$USERID/swww-$WAYLAND_DISPLAY.socket``, meaning that if two instances are running simultaneously, they don't conflict.

I also adjusted the daemon checking logic so that it scans for the file descriptor of the socket file open, so that two daemons won't get confused about each other.

This is my first substantial Rust PR; apologies if there's code issues or non-idiomatic things. I tried to keep to the code style of the project as much as possible.

Closes #272.