### PR TITLE
Add --no-cache option to swww-daemon

### DIFF
--- a/daemon/src/cli.rs
+++ b/daemon/src/cli.rs
@@ -3,11 +3,13 @@ use utils::ipc::PixelFormat;
 pub struct Cli {
     pub format: Option<PixelFormat>,
     pub quiet: bool,
+    pub no_cache: bool,
 }
 
 impl Cli {
     pub fn new() -> Self {
         let mut quiet = false;
+        let mut no_cache = false;
         let mut format = None;
         let mut args = std::env::args();
         args.next(); // skip the first argument
@@ -25,6 +27,7 @@ impl Cli {
                     }
                 },
                 "-q" | "--quiet" => quiet = true,
+                "--no-cache" => no_cache = true,
                 "-h" | "--help" => {
                     println!("swww-daemon");
                     println!();
@@ -39,6 +42,12 @@ impl Cli {
                     println!("          Only use this as a workaround when you run into problems.");
                     println!("          Whatever you chose, make sure you compositor actually supports it!");
                     println!("          'xrgb' is the most compatible one.");
+                    println!();
+                    println!("  --no-cache");
+                    println!(
+                        "          Don't search the cache for the last wallpaper for each output"
+                    );
+                    println!("          Useful if you always want to select which iamge `swww` loads manually using `swww img`");
                     println!();
                     println!("  -q|--quiet    will only log errors");
                     println!("  -h|--help     print help");
@@ -57,6 +66,10 @@ impl Cli {
             }
         }
 
-        Self { format, quiet }
+        Self {
+            format,
+            quiet,
+            no_cache,
+        }
     }
 }

--- a/daemon/src/cli.rs
+++ b/daemon/src/cli.rs
@@ -45,9 +45,9 @@ impl Cli {
                     println!();
                     println!("  --no-cache");
                     println!(
-                        "          Don't search the cache for the last wallpaper for each output"
+                        "         Don't search the cache for the last wallpaper for each output."
                     );
-                    println!("          Useful if you always want to select which iamge `swww` loads manually using `swww img`");
+                    println!("          Useful if you always want to select which image 'swww' loads manually using 'swww img'");
                     println!();
                     println!("  -q|--quiet    will only log errors");
                     println!("  -h|--help     print help");

--- a/daemon/src/wallpaper.rs
+++ b/daemon/src/wallpaper.rs
@@ -234,11 +234,11 @@ impl Wallpaper {
     }
 
     #[inline]
-    pub fn commit_surface_changes(&self) {
+    pub fn commit_surface_changes(&self, use_cache: bool) {
         let mut inner = self.inner.write().unwrap();
         let staging = self.inner_staging.lock().unwrap();
 
-        if inner.name != staging.name {
+        if inner.name != staging.name && use_cache {
             let name = staging.name.clone().unwrap_or("".to_string());
             if let Err(e) = std::thread::Builder::new()
                 .name("cache loader".to_string())

--- a/doc/swww-daemon.1.scd
+++ b/doc/swww-daemon.1.scd
@@ -4,7 +4,7 @@ swww-daemon(1)
 swww-daemon
 
 # SYNOPSIS
-swww-daemon [-q|--quiet] [-f|--format <xrgb|xbgr|rgb|bgr>]
+swww-daemon [-q|--quiet] [-f|--format <xrgb|xbgr|rgb|bgr>] [--no-cache]
 
 # OPTIONS
 
@@ -15,6 +15,11 @@ swww-daemon [-q|--quiet] [-f|--format <xrgb|xbgr|rgb|bgr>]
 	'swww-daemon' will automatically select the best format for itself during
 	initialization; this is only here for fallback, debug, and workaround
 	purposes.
+
+*--no-cache*
+	Don't search the cache for the last wallpaper for each output.
+	Useful if you always want to select which image 'swww' loads manually using
+	'swww img'
 
 *-q*,*--quiet*
 	Makes the daemon only log errors.


### PR DESCRIPTION
With the deprecation of `swww init`, `swww-daemon` was missing a key feature of allowing users to start the daemon without caching wallpapers from previous sessions. This is a step toward fixing this issue, although this still invalidates loading the cache even for new outputs (monitor re-connections).

If you're uncomfortable with blocking caching even for newer outputs and can point me to a different approach (as I'm pretty new to rust!), I'd gladly improve the PR :)