### PR TITLE
fix switching width and height

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -523,8 +523,26 @@ impl Dispatch<wl_output::WlOutput, ()> for Daemon {
         for wallpaper in state.wallpapers.iter_mut() {
             if wallpaper.has_id(proxy.id().protocol_id()) {
                 match event {
-                    wl_output::Event::Geometry { x, y, .. } => {
-                        debug!("output {} position: {x},{y}", proxy.id())
+                    wl_output::Event::Geometry {
+                        x, y, transform, ..
+                    } => {
+                        debug!("output {} position: {x},{y}", proxy.id());
+                        match transform {
+                            wayland_client::WEnum::Value(v) => match v {
+                                wl_output::Transform::_90
+                                | wl_output::Transform::_270
+                                | wl_output::Transform::Flipped90
+                                | wl_output::Transform::Flipped270 => wallpaper.set_vertical(),
+                                wl_output::Transform::Normal
+                                | wl_output::Transform::_180
+                                | wl_output::Transform::Flipped
+                                | wl_output::Transform::Flipped180 => wallpaper.set_horizontal(),
+                                e => warn!("unprocessed transform: {e:?}"),
+                            },
+                            wayland_client::WEnum::Unknown(u) => {
+                                error!("received unknown transfrom from compositor: {u}")
+                            }
+                        }
                     }
                     wl_output::Event::Mode {
                         flags: _flags,

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -147,7 +147,7 @@ fn main() -> Result<(), String> {
                 let output = globals
                     .registry()
                     .bind(global.name, global.version, &qh, ());
-                daemon.new_output(&qh, output);
+                daemon.new_output(&qh, output, global.name);
             } else {
                 error!("wl_output must be at least version 2 for swww-daemon!")
             }
@@ -469,7 +469,7 @@ impl Daemon {
             .collect()
     }
 
-    fn new_output(&mut self, qh: &QueueHandle<Self>, output: wl_output::WlOutput) {
+    fn new_output(&mut self, qh: &QueueHandle<Self>, output: wl_output::WlOutput, name: u32) {
         if PIXEL_FORMAT.get().is_none() {
             assert!(PIXEL_FORMAT.set(self.pixel_format).is_ok());
             log::info!("Selected wl_shm format: {:?}", self.shm_format);
@@ -501,6 +501,7 @@ impl Daemon {
         debug!("New output: {}", output.id());
         self.wallpapers.push(Arc::new(Wallpaper::new(
             output,
+            name,
             surface,
             wp_viewport,
             wp_fractional,
@@ -521,7 +522,7 @@ impl Dispatch<wl_output::WlOutput, ()> for Daemon {
         _qhandle: &QueueHandle<Self>,
     ) {
         for wallpaper in state.wallpapers.iter_mut() {
-            if wallpaper.has_id(proxy.id().protocol_id()) {
+            if wallpaper.has_output(proxy) {
                 match event {
                     wl_output::Event::Geometry {
                         x, y, transform, ..
@@ -709,13 +710,13 @@ impl Dispatch<WlRegistry, GlobalListContents> for Daemon {
                         error!("your compositor must support at least version 2 of wl_output");
                     } else {
                         let output = proxy.bind(name, version, qh, ());
-                        state.new_output(qh, output)
+                        state.new_output(qh, output, name)
                     }
                 }
             }
 
             wayland_client::protocol::wl_registry::Event::GlobalRemove { name } => {
-                state.wallpapers.retain(|w| !w.has_id(name));
+                state.wallpapers.retain(|w| !w.has_output_name(name));
 
                 debug!("Destroyed output with id: {name}");
             }

--- a/daemon/src/wallpaper.rs
+++ b/daemon/src/wallpaper.rs
@@ -200,6 +200,26 @@ impl Wallpaper {
     }
 
     #[inline]
+    pub fn set_vertical(&self) {
+        let mut lock = self.inner_staging.lock().unwrap();
+        if lock.width > lock.height {
+            let t = lock.width;
+            lock.width = lock.height;
+            lock.height = t;
+        }
+    }
+
+    #[inline]
+    pub fn set_horizontal(&self) {
+        let mut lock = self.inner_staging.lock().unwrap();
+        if lock.width < lock.height {
+            let t = lock.width;
+            lock.width = lock.height;
+            lock.height = t;
+        }
+    }
+
+    #[inline]
     pub fn set_scale(&self, scale: Scale) {
         let mut lock = self.inner_staging.lock().unwrap();
         if matches!(lock.scale_factor, Scale::Fractional(_)) && matches!(scale, Scale::Whole(_)) {

--- a/daemon/src/wallpaper.rs
+++ b/daemon/src/wallpaper.rs
@@ -79,6 +79,7 @@ impl Default for WallpaperInner {
 
 pub(super) struct Wallpaper {
     output: WlOutput,
+    output_name: u32,
     wl_surface: WlSurface,
     wp_viewport: WpViewport,
     #[allow(unused)]
@@ -98,8 +99,10 @@ pub(super) struct Wallpaper {
 }
 
 impl Wallpaper {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         output: WlOutput,
+        output_name: u32,
         wl_surface: WlSurface,
         wp_viewport: WpViewport,
         wp_fractional: Option<WpFractionalScaleV1>,
@@ -131,6 +134,7 @@ impl Wallpaper {
 
         Self {
             output,
+            output_name,
             wl_surface,
             wp_viewport,
             wp_fractional,
@@ -326,8 +330,13 @@ impl Wallpaper {
     }
 
     #[inline]
-    pub(super) fn has_id(&self, id: u32) -> bool {
-        wayland_client::Proxy::id(&self.output).protocol_id() == id
+    pub(super) fn has_output(&self, output: &WlOutput) -> bool {
+        self.output == *output
+    }
+
+    #[inline]
+    pub(super) fn has_output_name(&self, name: u32) -> bool {
+        self.output_name == name
     }
 
     #[inline]

--- a/daemon/src/wallpaper.rs
+++ b/daemon/src/wallpaper.rs
@@ -63,6 +63,7 @@ struct WallpaperInner {
     width: NonZeroI32,
     height: NonZeroI32,
     scale_factor: Scale,
+    is_vertical: bool,
 }
 
 impl Default for WallpaperInner {
@@ -73,6 +74,7 @@ impl Default for WallpaperInner {
             width: unsafe { NonZeroI32::new_unchecked(4) },
             height: unsafe { NonZeroI32::new_unchecked(4) },
             scale_factor: Scale::Whole(unsafe { NonZeroI32::new_unchecked(1) }),
+            is_vertical: false,
         }
     }
 }
@@ -201,26 +203,32 @@ impl Wallpaper {
                 )
             }
         }
+
+        if lock.is_vertical {
+            if lock.width > lock.height {
+                let t = lock.width;
+                lock.width = lock.height;
+                lock.height = t;
+            }
+        } else {
+            if lock.width < lock.height {
+                let t = lock.width;
+                lock.width = lock.height;
+                lock.height = t;
+            }
+        }
     }
 
     #[inline]
     pub fn set_vertical(&self) {
         let mut lock = self.inner_staging.lock().unwrap();
-        if lock.width > lock.height {
-            let t = lock.width;
-            lock.width = lock.height;
-            lock.height = t;
-        }
+        lock.is_vertical = true;
     }
 
     #[inline]
     pub fn set_horizontal(&self) {
         let mut lock = self.inner_staging.lock().unwrap();
-        if lock.width < lock.height {
-            let t = lock.width;
-            lock.width = lock.height;
-            lock.height = t;
-        }
+        lock.is_vertical = false;
     }
 
     #[inline]

--- a/utils/src/ipc.rs
+++ b/utils/src/ipc.rs
@@ -147,7 +147,12 @@ impl Scale {
     pub fn mul_dim(&self, width: i32, height: i32) -> (i32, i32) {
         match self {
             Scale::Whole(i) => (width * i.get(), height * i.get()),
-            Scale::Fractional(f) => ((width * f.get() + 60) / 120, (height * f.get() + 60) / 120),
+            Scale::Fractional(f) => {
+                let scale = f.get() as f64 / 120.0;
+                let width = (width as f64 * scale).round() as i32;
+                let height = (height as f64 * scale).round() as i32;
+                (width, height)
+            }
         }
     }
 
@@ -156,7 +161,12 @@ impl Scale {
     pub fn div_dim(&self, width: i32, height: i32) -> (i32, i32) {
         match self {
             Scale::Whole(i) => (width / i.get(), height / i.get()),
-            Scale::Fractional(f) => ((width * 120) / f.get(), (height * 120) / f.get()),
+            Scale::Fractional(f) => {
+                let scale = 120.0 / f.get() as f64;
+                let width = (width as f64 * scale).round() as i32;
+                let height = (height as f64 * scale).round() as i32;
+                (width, height)
+            }
         }
     }
 }


### PR DESCRIPTION
The previous fix called set_vertical before set_dimensions, causing the width and height to switch before getting their values. This PR add lock.is_vertical and swaps the weight and height in set_dimensions (after w and h receive their values) to resolve the issue. 

This PR has been tested on my machine with a vertical monitor, and it functions correctly.