### PR TITLE
Manual serializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "swww"
-version = "0.9.5"
+version = "0.9.5-master"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1388,9 +1388,8 @@ dependencies = [
 
 [[package]]
 name = "swww-daemon"
-version = "0.9.5"
+version = "0.9.5-master"
 dependencies = [
- "bitcode",
  "keyframe",
  "libc",
  "log",
@@ -1583,7 +1582,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utils"
-version = "0.9.5"
+version = "0.9.5-master"
 dependencies = [
  "bitcode",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,25 +158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
-name = "bitcode"
-version = "0.6.0"
-source = "git+https://github.com/SoftbearStudios/bitcode.git?rev=5f25a59#5f25a59be3e66deef721e7eb2369deb1aa32d263"
-dependencies = [
- "bitcode_derive",
- "bytemuck",
-]
-
-[[package]]
-name = "bitcode_derive"
-version = "0.6.0"
-source = "git+https://github.com/SoftbearStudios/bitcode.git?rev=5f25a59#5f25a59be3e66deef721e7eb2369deb1aa32d263"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,7 +1565,6 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 name = "utils"
 version = "0.9.5-master"
 dependencies = [
- "bitcode",
  "criterion",
  "pkg-config",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,6 +1568,7 @@ dependencies = [
  "criterion",
  "pkg-config",
  "rand",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "daemon"]
 
 [package]
 name = "swww"
-version = "0.9.5"
+version = "0.9.5-master"
 authors = ["Leonardo Gibrowski Faé <leonardo.fae44@gmail.com>"]
 edition = "2021"
 rust-version = "1.74"
@@ -34,7 +34,7 @@ image = "0.25"
 fast_image_resize = "3.0"
 clap = { version = "4.5", features = ["derive", "wrap_help", "env"] }
 rand = "0.8"
-utils = { version = "0.9.5", path = "utils" }
+utils = { version = "0.9.5-master", path = "utils" }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -14,7 +14,7 @@ wayland-client = { version = "0.31", default-features = false, features = [ "log
 wayland-protocols = { version = "0.31", default-features = false, features = [ "client", "staging" ]}
 wayland-protocols-wlr = { version = "0.2", default-features = false, features = [ "client" ]}
 
-rustix = { version = "0.38", default-features = false, features = [ "event", "shm", "mm", "net" ] }
+rustix = { version = "0.38", default-features = false, features = [ "event" ] }
 libc = "0.2"
 
 keyframe = "1.1"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swww-daemon"
-version = "0.9.5"
+version = "0.9.5-master"
 authors = ["Leonardo Gibrowski Faé <leonardo.fae44@gmail.com>"]
 edition = "2021"
 
@@ -14,8 +14,6 @@ wayland-client = { version = "0.31", default-features = false, features = [ "log
 wayland-protocols = { version = "0.31", default-features = false, features = [ "client", "staging" ]}
 wayland-protocols-wlr = { version = "0.2", default-features = false, features = [ "client" ]}
 
-# use specific git version for Duration implementation. We will do this until the next bitcode release
-bitcode = { git = "https://github.com/SoftbearStudios/bitcode.git", rev = "5f25a59", default-features = false }
 rustix = { version = "0.38", default-features = false, features = [ "event", "shm", "mm" ] }
 libc = "0.2"
 
@@ -25,6 +23,6 @@ spin_sleep = "1.2"
 
 sd-notify = { version = "0.4.1" }
 
-utils = { version = "0.9.5", path = "../utils" }
+utils = { version = "0.9.5-master", path = "../utils" }
 [dev-dependencies]
 rand = "0.8"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -14,7 +14,7 @@ wayland-client = { version = "0.31", default-features = false, features = [ "log
 wayland-protocols = { version = "0.31", default-features = false, features = [ "client", "staging" ]}
 wayland-protocols-wlr = { version = "0.2", default-features = false, features = [ "client" ]}
 
-rustix = { version = "0.38", default-features = false, features = [ "event", "shm", "mm" ] }
+rustix = { version = "0.38", default-features = false, features = [ "event", "shm", "mm", "net" ] }
 libc = "0.2"
 
 keyframe = "1.1"

--- a/daemon/src/animations/transitions.rs
+++ b/daemon/src/animations/transitions.rs
@@ -14,9 +14,9 @@ use keyframe::{
     functions::BezierCurve, keyframes, mint::Vector2, num_traits::Pow, AnimationSequence,
 };
 
-pub(super) struct Transition {
+pub(super) struct Transition<'a> {
     animation_tokens: Vec<AnimationToken>,
-    wallpapers: Vec<Arc<Wallpaper>>,
+    wallpapers: &'a mut Vec<Arc<Wallpaper>>,
     dimensions: (u32, u32),
     transition_type: TransitionType,
     duration: f32,
@@ -30,9 +30,9 @@ pub(super) struct Transition {
 }
 
 /// All transitions return whether or not they completed
-impl Transition {
+impl<'a> Transition<'a> {
     pub(super) fn new(
-        wallpapers: Vec<Arc<Wallpaper>>,
+        wallpapers: &'a mut Vec<Arc<Wallpaper>>,
         dimensions: (u32, u32),
         transition: &utils::ipc::Transition,
     ) -> Self {
@@ -76,9 +76,6 @@ impl Transition {
             TransitionType::Fade => self.fade(new_img),
         };
         debug!("Transitions finished");
-        for (wallpaper, token) in self.wallpapers.iter().zip(self.animation_tokens) {
-            token.set_transition_done(wallpaper);
-        }
     }
 
     fn updt_wallpapers(&mut self, now: &mut Instant) {

--- a/daemon/src/bump_pool.rs
+++ b/daemon/src/bump_pool.rs
@@ -1,19 +1,12 @@
 use std::{
-    io,
-    os::unix::prelude::{AsFd, OwnedFd},
+    os::unix::prelude::OwnedFd,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    time::{SystemTime, UNIX_EPOCH},
 };
 
-use rustix::{
-    io::Errno,
-    mm::{mmap, munmap, MapFlags, ProtFlags},
-    shm::{Mode, ShmOFlags},
-};
-
+use utils::ipc::Mmap;
 use wayland_client::{
     backend::ObjectData,
     protocol::{
@@ -96,71 +89,6 @@ impl Drop for Buffer {
 }
 
 #[derive(Debug)]
-struct Mmap {
-    fd: OwnedFd,
-    ptr: *mut std::ffi::c_void,
-    len: usize,
-}
-
-impl Mmap {
-    const PROT: ProtFlags = ProtFlags::WRITE.union(ProtFlags::READ);
-    const FLAGS: MapFlags = MapFlags::SHARED;
-
-    fn new(len: usize) -> Self {
-        let fd = create_shm_fd().unwrap();
-
-        loop {
-            match rustix::fs::ftruncate(&fd, len as u64) {
-                Err(Errno::INTR) => continue,
-                otherwise => break otherwise.unwrap(),
-            }
-        }
-
-        let ptr =
-            unsafe { mmap(std::ptr::null_mut(), len, Self::PROT, Self::FLAGS, &fd, 0).unwrap() };
-        Self { fd, ptr, len }
-    }
-
-    fn remap(&mut self, new_len: usize) {
-        if let Err(e) = unsafe { munmap(self.ptr, self.len) } {
-            log::error!("ERROR WHEN UNMAPPING MEMORY: {e}");
-        }
-        self.len = new_len;
-
-        loop {
-            match rustix::fs::ftruncate(&self.fd, self.len as u64) {
-                Err(Errno::INTR) => continue,
-                otherwise => break otherwise.unwrap(),
-            }
-        }
-
-        self.ptr = unsafe {
-            mmap(
-                std::ptr::null_mut(),
-                self.len,
-                Self::PROT,
-                Self::FLAGS,
-                &self.fd,
-                0,
-            )
-            .unwrap()
-        };
-    }
-
-    fn as_mut(&mut self) -> &mut [u8] {
-        unsafe { std::slice::from_raw_parts_mut(self.ptr.cast(), self.len) }
-    }
-}
-
-impl Drop for Mmap {
-    fn drop(&mut self) {
-        if let Err(e) = unsafe { munmap(self.ptr, self.len) } {
-            log::error!("ERROR WHEN UNMAPPING MEMORY: {e}");
-        }
-    }
-}
-
-#[derive(Debug)]
 /// A pool implementation that only gives buffers of a fixed size, creating new ones if none of
 /// them are freed. It also takes care of copying the previous buffer's content over to the new one
 /// for us
@@ -212,7 +140,7 @@ impl BumpPool {
         let len = self.buffer_len();
 
         let new_len = self.occupied_bytes() + len;
-        if new_len > self.mmap.len {
+        if new_len > self.mmap.len() {
             self.mmap.remap(new_len);
             self.pool.resize(new_len as i32);
         }
@@ -230,7 +158,7 @@ impl BumpPool {
         log::info!(
             "BumpPool with: {} buffers. Size: {}Kb",
             self.buffers.len(),
-            self.mmap.len / 1024
+            self.mmap.len() / 1024
         );
     }
 
@@ -258,12 +186,12 @@ impl BumpPool {
         if let Some(i) = self.last_used_buffer {
             let last_offset = self.buffer_offset(i);
             self.mmap
-                .as_mut()
+                .slice_mut()
                 .copy_within(last_offset..last_offset + len, offset);
         }
         self.last_used_buffer = Some(i);
 
-        &mut self.mmap.as_mut()[offset..offset + len]
+        &mut self.mmap.slice_mut()[offset..offset + len]
     }
 
     /// gets the last buffer we've drawn to
@@ -291,12 +219,12 @@ impl Drop for BumpPool {
 }
 
 fn new_pool(len: usize, shm: &WlShm) -> (WlShmPool, Mmap) {
-    let mmap = Mmap::new(len);
+    let mmap = Mmap::create(len);
 
     let pool = shm
         .send_constructor(
             wl_shm::Request::CreatePool {
-                fd: mmap.fd.as_fd(),
+                fd: mmap.fd(),
                 size: len as i32,
             },
             Arc::new(ShmPoolData),
@@ -304,72 +232,6 @@ fn new_pool(len: usize, shm: &WlShm) -> (WlShmPool, Mmap) {
         .expect("failed to create WlShmPool object");
 
     (pool, mmap)
-}
-
-fn create_shm_fd() -> io::Result<OwnedFd> {
-    #[cfg(target_os = "linux")]
-    {
-        match create_memfd() {
-            Ok(fd) => return Ok(fd),
-            // Not supported, use fallback.
-            Err(Errno::NOSYS) => (),
-            Err(err) => return Err(Into::<io::Error>::into(err)),
-        };
-    }
-
-    let time = SystemTime::now();
-    let mut mem_file_handle = format!(
-        "/swww-daemon-{}",
-        time.duration_since(UNIX_EPOCH).unwrap().subsec_nanos()
-    );
-
-    let flags = ShmOFlags::CREATE | ShmOFlags::EXCL | ShmOFlags::RDWR;
-    let mode = Mode::RUSR | Mode::WUSR;
-    loop {
-        match rustix::shm::shm_open(mem_file_handle.as_str(), flags, mode) {
-            Ok(fd) => match rustix::shm::shm_unlink(mem_file_handle.as_str()) {
-                Ok(_) => return Ok(fd),
-
-                Err(errno) => {
-                    return Err(errno.into());
-                }
-            },
-            Err(Errno::EXIST) => {
-                // Change the handle if we happen to be duplicate.
-                let time = SystemTime::now();
-
-                mem_file_handle = format!(
-                    "/swww-daemon-{}",
-                    time.duration_since(UNIX_EPOCH).unwrap().subsec_nanos()
-                );
-
-                continue;
-            }
-            Err(Errno::INTR) => continue,
-            Err(err) => return Err(err.into()),
-        }
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn create_memfd() -> rustix::io::Result<OwnedFd> {
-    use rustix::fs::{MemfdFlags, SealFlags};
-    use std::ffi::CStr;
-
-    let name = CStr::from_bytes_with_nul(b"swww-daemon\0").unwrap();
-    let flags = MemfdFlags::ALLOW_SEALING | MemfdFlags::CLOEXEC;
-
-    loop {
-        match rustix::fs::memfd_create(name, flags) {
-            Ok(fd) => {
-                // We only need to seal for the purposes of optimization, ignore the errors.
-                let _ = rustix::fs::fcntl_add_seals(&fd, SealFlags::SHRINK | SealFlags::SEAL);
-                return Ok(fd);
-            }
-            Err(Errno::INTR) => continue,
-            Err(err) => return Err(err),
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -362,7 +362,6 @@ impl Daemon {
     }
 
     fn recv_socket_msg(&mut self, stream: OwnedFd) {
-        let now = std::time::Instant::now();
         let bytes = match utils::ipc::read_socket(&stream) {
             Ok(bytes) => bytes,
             Err(e) => {
@@ -372,7 +371,6 @@ impl Daemon {
             }
         };
         let request = Request::receive(bytes);
-        log::error!("time to read request: {}us", now.elapsed().as_micros());
         let answer = match request {
             Request::Animation(AnimationRequest {
                 animations,

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -10,7 +10,6 @@ use log::{debug, error, info, warn, LevelFilter};
 use rustix::{
     event::{poll, PollFd, PollFlags},
     fd::OwnedFd,
-    path::Arg,
 };
 use simplelog::{ColorChoice, TermLogger, TerminalMode, ThreadLogMode};
 use wallpaper::Wallpaper;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -351,6 +351,7 @@ impl Daemon {
     }
 
     fn recv_socket_msg(&mut self, stream: UnixStream) {
+        let now = std::time::Instant::now();
         let bytes = match utils::ipc::read_socket(&stream) {
             Ok(bytes) => bytes,
             Err(e) => {
@@ -360,6 +361,7 @@ impl Daemon {
             }
         };
         let request = Request::receive(&bytes);
+        log::error!("time to read request: {}us", now.elapsed().as_micros());
         let answer = match request {
             Request::Animation(AnimationRequest {
                 animations,

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -374,7 +374,7 @@ impl Daemon {
             Request::Clear(clear) => {
                 let wallpapers = self.find_wallpapers_by_names(&clear.outputs);
                 let color = clear.color;
-                match std::thread::Builder::new()
+                let spawn_result = std::thread::Builder::new()
                     .stack_size(1 << 15)
                     .name("clear".to_string())
                     .spawn(move || {
@@ -386,7 +386,8 @@ impl Daemon {
                             wallpaper.clear(color);
                             wallpaper.draw();
                         }
-                    }) {
+                    });
+                match spawn_result {
                     Ok(_) => Answer::Ok,
                     Err(e) => Answer::Err(format!("failed to spawn `clear` thread: {e}")),
                 }
@@ -415,7 +416,8 @@ impl Daemon {
                     }
                     used_wallpapers.push(wallpapers);
                 }
-                self.animator.transition(transition, imgs, animations, used_wallpapers)
+                self.animator
+                    .transition(transition, imgs, animations, used_wallpapers)
             }
         };
         if let Err(e) = answer.send(&stream) {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -47,8 +47,8 @@ use wayland_client::{
 };
 
 use utils::ipc::{
-    connect_to_socket, get_socket_path, read_socket, AnimationRequest, Answer, BgInfo,
-    ImageRequest, PixelFormat, Request, Scale,
+    connect_to_socket, get_socket_path, read_socket, Answer, BgInfo, ImageRequest, PixelFormat,
+    Request, Scale,
 };
 
 use animations::Animator;
@@ -371,16 +371,6 @@ impl Daemon {
         };
         let request = Request::receive(bytes);
         let answer = match request {
-            Request::Animation(AnimationRequest {
-                animations,
-                outputs,
-            }) => {
-                let mut wallpapers = Vec::new();
-                for names in outputs.iter() {
-                    wallpapers.push(self.find_wallpapers_by_names(names));
-                }
-                self.animator.animate(animations, wallpapers)
-            }
             Request::Clear(clear) => {
                 let wallpapers = self.find_wallpapers_by_names(&clear.outputs);
                 let color = clear.color;
@@ -415,6 +405,7 @@ impl Daemon {
                 transition,
                 imgs,
                 outputs,
+                animations,
             }) => {
                 let mut used_wallpapers = Vec::new();
                 for names in outputs.iter() {
@@ -424,7 +415,7 @@ impl Daemon {
                     }
                     used_wallpapers.push(wallpapers);
                 }
-                self.animator.transition(transition, imgs, used_wallpapers)
+                self.animator.transition(transition, imgs, animations, used_wallpapers)
             }
         };
         if let Err(e) = answer.send(&stream) {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -371,7 +371,7 @@ impl Daemon {
                 return;
             }
         };
-        let request = Request::receive(&bytes);
+        let request = Request::receive(bytes);
         log::error!("time to read request: {}us", now.elapsed().as_micros());
         let answer = match request {
             Request::Animation(AnimationRequest {
@@ -848,7 +848,7 @@ pub fn is_daemon_running(addr: &PathBuf) -> Result<bool, String> {
     };
 
     Request::Ping.send(&sock)?;
-    let answer = Answer::receive(&read_socket(&sock)?);
+    let answer = Answer::receive(read_socket(&sock)?);
     match answer {
         Answer::Ping(_) => Ok(true),
         _ => Err("Daemon did not return Answer::Ping, as expected".to_string()),

--- a/daemon/src/wallpaper.rs
+++ b/daemon/src/wallpaper.rs
@@ -9,7 +9,7 @@ use std::{
     num::NonZeroI32,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
-        Arc, Condvar, Mutex, RwLock,
+        Condvar, Mutex, RwLock,
     },
 };
 
@@ -27,7 +27,6 @@ use crate::{bump_pool::BumpPool, Daemon, LayerSurface};
 #[derive(Debug)]
 struct AnimationState {
     id: AtomicUsize,
-    transition_finished: Arc<AtomicBool>,
 }
 
 #[derive(Debug)]
@@ -132,7 +131,6 @@ impl Wallpaper {
             inner_staging,
             animation_state: AnimationState {
                 id: AtomicUsize::new(0),
-                transition_finished: Arc::new(AtomicBool::new(false)),
             },
             configured: AtomicBool::new(false),
             qh: qh.clone(),
@@ -381,9 +379,6 @@ impl Wallpaper {
     #[inline]
     pub(super) fn stop_animations(&self) {
         self.animation_state.id.fetch_add(1, Ordering::AcqRel);
-        self.animation_state
-            .transition_finished
-            .store(false, Ordering::Release);
     }
 
     pub(super) fn clear(&self, color: [u8; 3]) {

--- a/daemon/src/wallpaper.rs
+++ b/daemon/src/wallpaper.rs
@@ -33,19 +33,6 @@ struct AnimationState {
 #[derive(Debug)]
 pub(super) struct AnimationToken {
     id: usize,
-    transition_done: Arc<AtomicBool>,
-}
-
-impl AnimationToken {
-    pub(super) fn is_transition_done(&self) -> bool {
-        self.transition_done.load(Ordering::Acquire)
-    }
-
-    pub(super) fn set_transition_done(&self, wallpaper: &Wallpaper) {
-        if wallpaper.has_animation_id(self) {
-            self.transition_done.store(true, Ordering::Release);
-        }
-    }
 }
 
 struct FrameCallbackHandler {
@@ -381,10 +368,7 @@ impl Wallpaper {
     #[inline]
     pub(super) fn create_animation_token(&self) -> AnimationToken {
         let id = self.animation_state.id.load(Ordering::Acquire);
-        AnimationToken {
-            id,
-            transition_done: Arc::clone(&self.animation_state.transition_finished),
-        }
+        AnimationToken { id }
     }
 
     #[inline]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), String> {
     }
 
     if let Swww::ClearCache = &swww {
-        return cache::clean();
+        return cache::clean().map_err(|e| format!("failed to clean the cache: {e}"));
     }
 
     loop {
@@ -362,7 +362,8 @@ fn restore_from_cache(requested_outputs: &[String]) -> Result<(), String> {
     let (_, _, outputs) = get_format_dims_and_outputs(requested_outputs)?;
 
     for output in outputs.iter().flatten() {
-        let img_path = utils::cache::get_previous_image_path(output)?;
+        let img_path = utils::cache::get_previous_image_path(output)
+            .map_err(|e| format!("failed to get previous image path: {e}"))?;
         #[allow(deprecated)]
         if let Err(e) = process_swww_args(&Swww::Img(cli::Img {
             path: PathBuf::from(img_path),

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), String> {
         let socket = connect_to_socket(&get_socket_path(), 5, 100)?;
         Request::Ping.send(&socket)?;
         let bytes = read_socket(&socket)?;
-        let answer = Answer::receive(&bytes);
+        let answer = Answer::receive(bytes);
         if let Answer::Ping(configured) = answer {
             if configured {
                 break;
@@ -88,7 +88,7 @@ fn process_swww_args(args: &Swww) -> Result<(), String> {
     request.send(&socket)?;
     let bytes = read_socket(&socket)?;
     drop(socket);
-    match Answer::receive(&bytes) {
+    match Answer::receive(bytes) {
         Answer::Err(msg) => return Err(msg.to_string()),
         Answer::Info(info) => info.iter().for_each(|i| println!("{}", i)),
         Answer::Ok => {
@@ -149,7 +149,7 @@ fn make_request(args: &Swww) -> Result<Option<Request>, String> {
                     Request::Img(img_request).send(&socket)?;
                     let bytes = read_socket(&socket)?;
                     drop(socket);
-                    if let Answer::Err(e) = Answer::receive(&bytes) {
+                    if let Answer::Err(e) = Answer::receive(bytes) {
                         return Err(format!("daemon error when sending image: {e}"));
                     }
                     animations
@@ -224,7 +224,7 @@ fn get_format_dims_and_outputs(
     Request::Query.send(&socket)?;
     let bytes = read_socket(&socket)?;
     drop(socket);
-    let answer = Answer::receive(&bytes);
+    let answer = Answer::receive(bytes);
     match answer {
         Answer::Info(infos) => {
             let mut format = ipc::PixelFormat::Xrgb;
@@ -351,7 +351,7 @@ fn is_daemon_running() -> Result<bool, String> {
     };
 
     Request::Ping.send(&socket)?;
-    let answer = Answer::receive(&read_socket(&socket)?);
+    let answer = Answer::receive(read_socket(&socket)?);
     match answer {
         Answer::Ping(_) => Ok(true),
         _ => Err("Daemon did not return Answer::Ping, as expected".to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,20 +270,16 @@ fn make_animation_request(
     let mut anim_req_builder = ipc::AnimationRequestBuilder::new();
 
     let filter = make_filter(&img.filter);
-    let mut animations = Vec::with_capacity(dims.len());
     for (dim, outputs) in dims.iter().zip(outputs) {
-        // do not load cache if we are reading from stdin
-        if let Some("-") = img.path.to_str() {
-            //TODO: make cache work for all resize strategies
-            if img.resize == ResizeStrategy::Crop {
-                match cache::load_animation_frames(&img.path, *dim, pixel_format) {
-                    Ok(Some(animation)) => {
-                        animations.push((animation, outputs.to_owned().into_boxed_slice()));
-                        continue;
-                    }
-                    Ok(None) => (),
-                    Err(e) => eprintln!("Error loading cache for {:?}: {e}", img.path),
+        //TODO: make cache work for all resize strategies
+        if img.resize == ResizeStrategy::Crop {
+            match cache::load_animation_frames(&img.path, *dim, pixel_format) {
+                Ok(Some(animation)) => {
+                    anim_req_builder.push(animation, outputs.to_owned().into_boxed_slice());
+                    continue;
                 }
+                Ok(None) => (),
+                Err(e) => eprintln!("Error loading cache for {:?}: {e}", img.path),
             }
         }
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
-# use specific git version for Duration implementation. We will do this until the next bitcode release
-bitcode = { git = "https://github.com/SoftbearStudios/bitcode.git", rev = "5f25a59", default-features = false, features = [ "derive" ]}
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.9.5"
+version = "0.9.5-master"
 authors = ["Leonardo Gibrowski Faé <leonardo.fae44@gmail.com>"]
 edition = "2021"
 license-file = "../LICENSE"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license-file = "../LICENSE"
 
 [dependencies]
+rustix = { version = "0.38", default-features = false, features = [ "net", "shm", "mm" ] }
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -6,24 +6,19 @@
 
 use std::{
     fs::File,
-    io::{BufReader, BufWriter, Read, Write},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
 };
 
 use crate::ipc::{Animation, PixelFormat};
 
-pub fn store(output_name: &str, img_path: &str) -> Result<(), String> {
+pub fn store(output_name: &str, img_path: &str) -> io::Result<()> {
     let mut filepath = cache_dir()?;
     filepath.push(output_name);
-    let file = File::create(filepath).map_err(|e| e.to_string())?;
-
-    let mut writer = BufWriter::new(file);
-    writer
-        .write_all(img_path.as_bytes())
-        .map_err(|e| format!("failed to write cache: {e}"))
+    File::create(filepath)?.write_all(img_path.as_bytes())
 }
 
-pub fn store_animation_frames(animation: &Animation) -> Result<(), String> {
+pub fn store_animation_frames(animation: &Animation) -> io::Result<()> {
     let filename = animation_filename(
         &PathBuf::from(&animation.path),
         animation.dimensions,
@@ -36,9 +31,7 @@ pub fn store_animation_frames(animation: &Animation) -> Result<(), String> {
     animation.serialize(&mut bytes);
 
     if !filepath.is_file() {
-        let mut file = File::create(filepath).map_err(|e| e.to_string())?;
-        file.write_all(&bytes)
-            .map_err(|e| format!("failed to write cache: {e}"))
+        File::create(filepath)?.write_all(&bytes)
     } else {
         Ok(())
     }
@@ -48,22 +41,18 @@ pub fn load_animation_frames(
     path: &Path,
     dimensions: (u32, u32),
     pixel_format: PixelFormat,
-) -> Result<Option<Animation>, String> {
+) -> io::Result<Option<Animation>> {
     let filename = animation_filename(path, dimensions, pixel_format);
     let cache_dir = cache_dir()?;
     let mut filepath = cache_dir.clone();
     filepath.push(filename);
 
-    let read_dir = cache_dir
-        .read_dir()
-        .map_err(|e| format!("failed to read cache directory ({cache_dir:?}): {e}"))?;
+    let read_dir = cache_dir.read_dir()?;
 
     for entry in read_dir.into_iter().flatten() {
         if entry.path() == filepath {
-            let mut file = File::open(&filepath).map_err(|e| e.to_string())?;
             let mut buf = Vec::new();
-            file.read_to_end(&mut buf)
-                .map_err(|e| format!("failed to read file `{filepath:?}`: {e}"))?;
+            File::open(&filepath)?.read_to_end(&mut buf)?;
 
             let (frames, _) = Animation::deserialize(&buf);
             return Ok(Some(frames));
@@ -72,7 +61,7 @@ pub fn load_animation_frames(
     Ok(None)
 }
 
-pub fn get_previous_image_path(output_name: &str) -> Result<String, String> {
+pub fn get_previous_image_path(output_name: &str) -> io::Result<String> {
     let mut filepath = cache_dir()?;
     clean_previous_verions(&filepath);
 
@@ -80,17 +69,19 @@ pub fn get_previous_image_path(output_name: &str) -> Result<String, String> {
     if !filepath.is_file() {
         return Ok("".to_string());
     }
-    let file = std::fs::File::open(filepath).map_err(|e| format!("failed to open file: {e}"))?;
-    let mut reader = BufReader::new(file);
-    let mut buf = Vec::with_capacity(64);
-    reader
-        .read_to_end(&mut buf)
-        .map_err(|e| format!("failed to read file: {e}"))?;
 
-    String::from_utf8(buf).map_err(|e| format!("failed to decode bytes: {e}"))
+    let mut buf = Vec::with_capacity(64);
+    File::open(filepath)?.read_to_end(&mut buf)?;
+
+    String::from_utf8(buf).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("failed to decode bytes: {e}"),
+        )
+    })
 }
 
-pub fn load(output_name: &str) -> Result<(), String> {
+pub fn load(output_name: &str) -> io::Result<()> {
     let img_path = get_previous_image_path(output_name)?;
     if img_path.is_empty() {
         return Ok(());
@@ -99,31 +90,28 @@ pub fn load(output_name: &str) -> Result<(), String> {
     if let Ok(mut child) = std::process::Command::new("pidof").arg("swww").spawn() {
         if let Ok(status) = child.wait() {
             if status.success() {
-                return Err("there is already another swww process running".to_string());
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "there is already another swww process running".to_string(),
+                ));
             }
         }
     }
 
-    match std::process::Command::new("swww")
+    std::process::Command::new("swww")
         .arg("img")
         .args([
             &format!("--outputs={output_name}"),
             "--transition-type=none",
             &img_path,
         ])
-        .spawn()
-    {
-        Ok(mut child) => match child.wait() {
-            Ok(_) => Ok(()),
-            Err(e) => Err(format!("child process failed: {e}")),
-        },
-        Err(e) => Err(format!("failed to spawn child process: {e}")),
-    }
+        .spawn()?
+        .wait()?;
+    Ok(())
 }
 
-pub fn clean() -> Result<(), String> {
+pub fn clean() -> io::Result<()> {
     std::fs::remove_dir_all(cache_dir()?)
-        .map_err(|e| format!("failed to remove cache directory: {e}"))
 }
 
 fn clean_previous_verions(cache_dir: &Path) {
@@ -161,16 +149,15 @@ fn clean_previous_verions(cache_dir: &Path) {
     }
 }
 
-fn create_dir(p: &Path) -> Result<(), String> {
+fn create_dir(p: &Path) -> io::Result<()> {
     if !p.is_dir() {
-        if let Err(e) = std::fs::create_dir(p) {
-            return Err(format!("failed to create directory({p:#?}): {e}"));
-        }
+        std::fs::create_dir(p)
+    } else {
+        Ok(())
     }
-    Ok(())
 }
 
-fn cache_dir() -> Result<PathBuf, String> {
+fn cache_dir() -> io::Result<PathBuf> {
     if let Ok(path) = std::env::var("XDG_CACHE_HOME") {
         let mut path: PathBuf = path.into();
         path.push("swww");
@@ -183,7 +170,10 @@ fn cache_dir() -> Result<PathBuf, String> {
         create_dir(&path)?;
         Ok(path)
     } else {
-        Err("failed to read both $XDG_CACHE_HOME and $HOME environment variables".to_string())
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "failed to read both $XDG_CACHE_HOME and $HOME environment variables".to_string(),
+        ))
     }
 }
 

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -54,8 +54,10 @@ pub fn load_animation_frames(
             let mut buf = Vec::new();
             File::open(&filepath)?.read_to_end(&mut buf)?;
 
-            let (frames, _) = Animation::deserialize(&buf);
-            return Ok(Some(frames));
+            match std::panic::catch_unwind(|| Animation::deserialize(&buf)) {
+                Ok((frames, _)) => return Ok(Some(frames)),
+                Err(e) => eprintln!("Error loading animation frames: {e:?}"),
+            }
         }
     }
     Ok(None)

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -12,18 +12,19 @@ use std::{
 
 use crate::ipc::{Animation, PixelFormat};
 
-pub fn store(output_name: &str, img_path: &str) -> io::Result<()> {
+pub(crate) fn store(output_name: &str, img_path: &str) -> io::Result<()> {
     let mut filepath = cache_dir()?;
     filepath.push(output_name);
     File::create(filepath)?.write_all(img_path.as_bytes())
 }
 
-pub fn store_animation_frames(animation: &Animation) -> io::Result<()> {
-    let filename = animation_filename(
-        &PathBuf::from(&animation.path),
-        animation.dimensions,
-        animation.pixel_format,
-    );
+pub(crate) fn store_animation_frames(
+    animation: &Animation,
+    path: &Path,
+    dimensions: (u32, u32),
+    pixel_format: PixelFormat,
+) -> io::Result<()> {
+    let filename = animation_filename(path, dimensions, pixel_format);
     let mut filepath = cache_dir()?;
     filepath.push(&filename);
 

--- a/utils/src/compression/mod.rs
+++ b/utils/src/compression/mod.rs
@@ -6,8 +6,6 @@ use comp::pack_bytes;
 use decomp::{unpack_bytes_3channels, unpack_bytes_4channels};
 use std::ffi::{c_char, c_int};
 
-use bitcode::{Decode, Encode};
-
 use crate::ipc::PixelFormat;
 mod comp;
 mod cpu;
@@ -45,14 +43,47 @@ extern "C" {
 }
 
 /// This struct represents the cached difference between the previous frame and the next
-#[derive(Encode, Decode)]
 pub struct BitPack {
     inner: Box<[u8]>,
     /// This field will ensure we won't ever try to unpack the images on a buffer of the wrong size,
     /// which ultimately is what allows us to use unsafe in the unpack_bytes function
-    expected_buf_size: usize,
+    expected_buf_size: u32,
 
     compressed_size: i32,
+}
+
+impl BitPack {
+    pub(crate) fn serialize(&self, buf: &mut Vec<u8>) {
+        let Self {
+            inner,
+            expected_buf_size,
+            compressed_size,
+        } = self;
+        buf.extend((inner.len() as u32).to_ne_bytes());
+        buf.extend(inner.iter());
+        buf.extend((expected_buf_size).to_ne_bytes());
+        buf.extend((compressed_size).to_ne_bytes());
+    }
+
+    pub(crate) fn deserialize(bytes: &[u8]) -> (Self, usize) {
+        let mut i = 0;
+        let len = unsafe { bytes.as_ptr().add(i).cast::<u32>().read_unaligned() } as usize;
+        i += 4;
+        let inner = bytes[i..i + len].into();
+        i += len;
+        let expected_buf_size = unsafe { bytes.as_ptr().add(i).cast::<u32>().read_unaligned() };
+        i += 4;
+        let compressed_size = unsafe { bytes.as_ptr().add(i).cast::<i32>().read_unaligned() };
+        i += 4;
+        (
+            Self {
+                inner,
+                expected_buf_size,
+                compressed_size,
+            },
+            i,
+        )
+    }
 }
 
 /// Struct responsible for compressing our data. We use it to cache vector extensions that might
@@ -123,9 +154,9 @@ impl Compressor {
         v.truncate(n);
 
         let expected_buf_size = if pixel_format.channels() == 3 {
-            cur.len()
+            cur.len() as u32
         } else {
-            (cur.len() / 3) * 4
+            ((cur.len() / 3) * 4) as u32
         };
 
         Some(BitPack {
@@ -200,7 +231,7 @@ impl Decompressor {
         buf: &mut [u8],
         pixel_format: PixelFormat,
     ) -> Result<(), String> {
-        if buf.len() != bitpack.expected_buf_size {
+        if buf.len() != bitpack.expected_buf_size as usize {
             return Err(format!(
                 "buf has len {}, but expected len is {}",
                 buf.len(),

--- a/utils/src/ipc.rs
+++ b/utils/src/ipc.rs
@@ -906,7 +906,7 @@ pub struct SocketMsg {
 }
 
 pub fn read_socket(stream: &OwnedFd) -> Result<SocketMsg, String> {
-    let mut buf = [0; 16];
+    let mut buf = [0u8; 16];
     let mut ancillary_buf = [0u8; rustix::cmsg_space!(ScmRights(1))];
 
     let mut control = net::RecvAncillaryBuffer::new(&mut ancillary_buf);
@@ -965,35 +965,6 @@ pub fn get_socket_path() -> PathBuf {
     socket_path.push(socket_name);
 
     socket_path
-}
-
-pub fn get_cache_path() -> Result<PathBuf, String> {
-    let cache_path = match std::env::var("XDG_CACHE_HOME") {
-        Ok(dir) => {
-            let mut cache = PathBuf::from(dir);
-            cache.push("swww");
-            cache
-        }
-        Err(_) => match std::env::var("HOME") {
-            Ok(dir) => {
-                let mut cache = PathBuf::from(dir);
-                cache.push(".cache/swww");
-                cache
-            }
-            Err(_) => return Err("failed to read both XDG_CACHE_HOME and HOME env vars".to_owned()),
-        },
-    };
-
-    if !cache_path.is_dir() {
-        if let Err(e) = std::fs::create_dir(&cache_path) {
-            return Err(format!(
-                "failed to create cache_path \"{}\": {e}",
-                cache_path.display()
-            ));
-        }
-    }
-
-    Ok(cache_path)
 }
 
 /// We make sure the Stream is always set to blocking mode

--- a/utils/src/ipc.rs
+++ b/utils/src/ipc.rs
@@ -625,7 +625,6 @@ pub enum Request {
 
 impl Request {
     pub fn send(&self, stream: &OwnedFd) -> Result<(), String> {
-        let now = std::time::Instant::now();
         let mut socket_msg = [0u8; 16];
         socket_msg[0..8].copy_from_slice(&match self {
             Request::Ping => 0u64.to_ne_bytes(),
@@ -696,11 +695,6 @@ impl Request {
             }
             _ => vec![],
         };
-        println!(
-            "Send encode time: {}us, size: {}",
-            now.elapsed().as_micros(),
-            bytes.len()
-        );
         std::thread::scope(|s| {
             if let Self::Animation(AnimationRequest { animations, .. }) = self {
                 s.spawn(|| {
@@ -760,7 +754,6 @@ impl Request {
     #[must_use]
     #[inline]
     pub fn receive(socket_msg: SocketMsg) -> Self {
-        let now = std::time::Instant::now();
         let ret = match socket_msg.code {
             0 => Self::Ping,
             1 => Self::Query,
@@ -875,7 +868,6 @@ impl Request {
             }
             _ => Self::Kill,
         };
-        println!("Receive decode time: {}us", now.elapsed().as_micros());
         ret
     }
 }

--- a/utils/src/ipc.rs
+++ b/utils/src/ipc.rs
@@ -634,7 +634,10 @@ impl Request {
         {
             for i in 0..outputs.len() {
                 let Img {
-                    path, dim: dims, format, ..
+                    path,
+                    dim: dims,
+                    format,
+                    ..
                 } = &imgs[i];
                 for output in outputs[i].iter() {
                     if let Err(e) = super::cache::store(output, path) {
@@ -1125,7 +1128,7 @@ fn create_memfd() -> rustix::io::Result<OwnedFd> {
     use rustix::fs::{MemfdFlags, SealFlags};
     use std::ffi::CStr;
 
-    let name = CStr::from_bytes_with_nul(b"swww-daemon\0").unwrap();
+    let name = CStr::from_bytes_with_nul(b"swww-ipc\0").unwrap();
     let flags = MemfdFlags::ALLOW_SEALING | MemfdFlags::CLOEXEC;
 
     loop {


### PR DESCRIPTION
Handwritten serializer and deserializar. It is faster, using the same amount of memory.

We are now using a shared memory file to transfer large amounts of data between the daemon and the client. This makes communication between the two faster still.

Finally, we've merged the Image and Animation requests into a single one, halving the amount of round-trips necessary to send in an animated image.