### PR TITLE
Nix: allow building swww from the source directly

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,22 @@
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+    # - cron: '0 0 * * *' # runs everyday at 00:00
+  push:
+      paths:
+        - 'flake.nix'
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v25
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v21

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/*
 completions/*
 test_images/*
+# Nix
+result

--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ The man pages will be in `doc/generated`. To install them, you must move them to
 to the appropriate location in your system. You should be able to figure out
 where that is by running `manpath`.
 
+### Nix
+
+NixOS users can directly use this repository to get the latest swww for their system.
+
+Add in your `flake.nix`:
+
+```nix
+  inputs.swww.url = "github:LGFae/swww";
+```
+
+Pass inputs to your modules using `specialArgs` and
+Then in `configuration.nix`:
+
+```nix
+  environment.systemPackages = [
+    inputs.swww.packages.${pkgs.system}.swww
+  ];
+```
+
 ## Features
 
  - Display animated gifs on your desktop

--- a/build.nix
+++ b/build.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  lz4,
+  libxkbcommon,
+  installShellFiles,
+  scdoc,
+  nix-gitignore,
+}: let
+  version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+  src = nix-gitignore.gitignoreSource [] ./.;
+in
+rustPlatform.buildRustPackage {
+  pname = "swww";
+
+  inherit src version;
+
+  cargoLock.lockFile = ./Cargo.lock;
+
+  buildInputs = [
+    lz4
+    libxkbcommon
+  ];
+
+  doCheck = false; # Integration tests do not work in sandbox environment
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+    scdoc
+  ];
+
+  postInstall = ''
+    for f in doc/*.scd; do
+      local page="doc/$(basename "$f" .scd)"
+      scdoc < "$f" > "$page"
+      installManPage "$page"
+    done
+
+    installShellCompletion --cmd swww \
+      --bash completions/swww.bash \
+      --fish completions/swww.fish \
+      --zsh completions/_swww
+  '';
+
+  meta = {
+    description = "Efficient animated wallpaper daemon for wayland, controlled at runtime";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    mainProgram = "swww";
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,6 @@
+(import (let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+in fetchTarball {
+  url =
+    "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+  sha256 = lock.nodes.flake-compat.locked.narHash;
+}) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1715447595,
+        "narHash": "sha256-VsVAUQOj/cS1LCOmMjAGeRksXIAdPnFIjCQ0XLkCsT0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "062ca2a9370a27a35c524dc82d540e6e9824b652",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "swww, A Solution to your Wayland Wallpaper Woes";
+
+  # Nixpkgs / NixOS version to use.
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.utils.url = "github:numtide/flake-utils";
+  inputs.flake-compat = {
+    url = "github:edolstra/flake-compat";
+    flake = false;
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    utils,
+    ...
+  }:
+    {
+      overlays.default = final: prev: {
+        swww = final.callPackage ./build.nix {};
+      };
+    }
+    // utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [self.overlays.default];
+      };
+    in {
+      packages = {
+        inherit (pkgs) swww;
+        default = pkgs.swww;
+      };
+
+      formatter = pkgs.alejandra;
+
+      devShells.default = pkgs.callPackage ({
+        mkShell,
+        rustc,
+        cargo,
+        gnumake,
+        pkg-config,
+        lz4,
+        libxkbcommon,
+        swww,
+      }:
+        mkShell {
+          inherit (swww) nativeBuildInputs buildInputs;
+        }) {};
+    });
+}


### PR DESCRIPTION
This PR adds support for building nix binaries directly from this repo.

NixOS user's can easily add this repo to their `flake.nix` and use the latest version directly from this repository.

<details>

```nix
  inputs.swww.url = "github:LGFae/swww";
```

Then in `configuration.nix`

```nix
  environment.systemPackages = [
    inputs.swww.packages.${pkgs.system}.swww
  ];
```
</details>

Build instructions for nix after cloning this repo:
<details>

With `nix-build`:
```bash
nix-build
```
With `nix build` (flakes):
```bash
nix build .#swww
```

</details>

## Why?
Motivation for this comes from the need to have a swww-git package on NixOS to get the latest changes.
However nixpkgs is inefficient for hosting a `-git` package, since approval and merging of PRs do take a lot of time. Adventurous users can use the flake directly to stay upto date on the latest bugfixes and features.

A lot of packages already [utilise this](https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29flake%5C.nix%24%2F&type=code) to provide nix packages directly from their source repository. 

## To-Do
- [x] README docs need to be updated.
- [x] Implement a workflow that'll automatically update the dependencies