### PR TITLE
workflows: add nix-tests workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,5 @@ jobs:
     uses: ./.github/workflows/dependencies.yml
   test:
     uses: ./.github/workflows/test.yml
+  nix-tests:
+    uses: ./.github/workflows/nix-tests.yml

--- a/.github/workflows/nix-tests.yml
+++ b/.github/workflows/nix-tests.yml
@@ -1,0 +1,17 @@
+name: "Nix-Tests"
+on:
+    workflow_call:
+
+jobs:
+  nix-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v27
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - run: nix flake show
+    - run: nix flake check --print-build-logs
+    - run: nix build --print-build-logs

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -2,8 +2,7 @@ name: update-flake-lock
 on:
   workflow_dispatch: # allows manual triggering
   schedule:
-    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
-    # - cron: '0 0 * * *' # runs everyday at 00:00
+    - cron: '0 0 1 * *' # Run monthly
   push:
       paths:
         - 'flake.nix'
@@ -14,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Nix
-        uses: cachix/install-nix-action@v25
+        uses: cachix/install-nix-action@v27
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds one workflow:

1. nix-tests - checks nix files, builds the package, on every push and PR
2. Updates `update-flake-lock` to run monthly, as there is no need to update dependencies weekly

Workflow-demo: [nix-tests](https://github.com/LGFae/swww/actions/runs/9265935709/job/25489044406?pr=319)