### PR TITLE
trim dependencies: criterion features and fastrand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,12 +123,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
 name = "bytemuck"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,8 +266,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "oorandom",
- "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -389,6 +381,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,17 +412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
  "spin",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -526,15 +513,6 @@ name = "jpeg-decoder"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
-
-[[package]]
-name = "js-sys"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
-dependencies = [
- "wasm-bindgen",
-]
 
 [[package]]
 name = "keyframe"
@@ -643,34 +621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "plotters"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "png"
 version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,12 +632,6 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
@@ -741,46 +685,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
 ]
 
 [[package]]
@@ -928,8 +832,8 @@ dependencies = [
  "clap",
  "clap_complete",
  "fast_image_resize",
+ "fastrand",
  "image",
- "rand",
  "utils",
 ]
 
@@ -940,7 +844,6 @@ dependencies = [
  "keyframe",
  "libc",
  "log",
- "rand",
  "rustix",
  "sd-notify",
  "utils",
@@ -1031,8 +934,8 @@ name = "utils"
 version = "0.9.5-masterV2"
 dependencies = [
  "criterion",
+ "fastrand",
  "pkg-config",
- "rand",
  "rustix",
 ]
 
@@ -1053,76 +956,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
-
-[[package]]
-name = "web-sys"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ image = { version = "0.25", default-features = false, features = [
 ]}
 fast_image_resize = "4.0"
 clap = { version = "4.5", features = ["derive", "wrap_help", "env"] }
-rand = "0.8"
+fastrand = { version = "2.1", default-features = false, features = [ "std" ] }
 utils = { version = "0.9.5-masterV2", path = "utils" }
 
 [dev-dependencies]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -17,5 +17,3 @@ keyframe = "1.1"
 sd-notify = { version = "0.4.1" }
 
 utils = { version = "0.9.5-masterV2", path = "../utils" }
-[dev-dependencies]
-rand = "0.8"

--- a/src/imgproc.rs
+++ b/src/imgproc.rs
@@ -482,10 +482,10 @@ pub fn make_transition(img: &cli::Img) -> ipc::Transition {
         }
         cli::TransitionType::Any => {
             pos = Position::new(
-                Coord::Percent(rand::random::<f32>()),
-                Coord::Percent(rand::random::<f32>()),
+                Coord::Percent(fastrand::f32()),
+                Coord::Percent(fastrand::f32()),
             );
-            if rand::random::<u8>() % 2 == 0 {
+            if fastrand::bool() {
                 ipc::TransitionType::Grow
             } else {
                 ipc::TransitionType::Outer
@@ -493,11 +493,11 @@ pub fn make_transition(img: &cli::Img) -> ipc::Transition {
         }
         cli::TransitionType::Random => {
             pos = Position::new(
-                Coord::Percent(rand::random::<f32>()),
-                Coord::Percent(rand::random::<f32>()),
+                Coord::Percent(fastrand::f32()),
+                Coord::Percent(fastrand::f32()),
             );
-            angle = rand::random();
-            match rand::random::<u8>() % 4 {
+            angle = fastrand::f64();
+            match fastrand::u8(0..4) {
                 0 => ipc::TransitionType::Simple,
                 1 => ipc::TransitionType::Wipe,
                 2 => ipc::TransitionType::Outer,

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -12,8 +12,8 @@ rustix = { version = "0.38", default-features = false, features = [ "std", "net"
 pkg-config = "0.3"
 
 [dev-dependencies]
-rand = "0.8"
-criterion = "0.5"
+fastrand = { version = "2.1", default-features = false, features = [ "std" ] }
+criterion = { version = "0.5", default-features = false }
 
 [[bench]]
 name = "compression"

--- a/utils/src/compression/comp/sse2.rs
+++ b/utils/src/compression/comp/sse2.rs
@@ -118,7 +118,6 @@ pub(super) unsafe fn pack_bytes(cur: &[u8], goal: &[u8], v: &mut Vec<u8>) {
 mod tests {
     use super::*;
     use crate::compression::unpack_bytes_4channels;
-    use rand::prelude::random;
 
     #[test]
     fn count_equal_test() {
@@ -186,7 +185,7 @@ mod tests {
             for _ in 0..20 {
                 let mut v = Vec::with_capacity(3000);
                 for _ in 0..3000 {
-                    v.push(random::<u8>());
+                    v.push(fastrand::u8(..));
                 }
                 original.push(v);
             }
@@ -233,13 +232,13 @@ mod tests {
                 let mut v = Vec::with_capacity(3006);
                 v.extend([j, 0, 0, 0, 0, j]);
                 for _ in 0..750 {
-                    v.push(random::<u8>());
+                    v.push(fastrand::u8(..));
                 }
                 for i in 0..750 {
                     v.push((i % 255) as u8);
                 }
                 for _ in 0..750 {
-                    v.push(random::<u8>());
+                    v.push(fastrand::u8(..));
                 }
                 for i in 0..750 {
                     v.push((i % 255) as u8);

--- a/utils/src/compression/decomp/ssse3.rs
+++ b/utils/src/compression/decomp/ssse3.rs
@@ -58,7 +58,6 @@ pub(super) unsafe fn unpack_bytes_4channels(buf: &mut [u8], diff: &[u8]) {
 mod tests {
     use super::*;
     use crate::compression::pack_bytes;
-    use rand::prelude::random;
 
     fn buf_from(slice: &[u8]) -> Vec<u8> {
         let mut v = Vec::new();
@@ -102,7 +101,7 @@ mod tests {
             for _ in 0..20 {
                 let mut v = Vec::with_capacity(3000);
                 for _ in 0..3000 {
-                    v.push(random::<u8>());
+                    v.push(fastrand::u8(..));
                 }
                 original.push(v);
             }
@@ -148,13 +147,13 @@ mod tests {
             for _ in 0..20 {
                 let mut v = Vec::with_capacity(3000);
                 for _ in 0..750 {
-                    v.push(random::<u8>());
+                    v.push(fastrand::u8(..));
                 }
                 for i in 0..750 {
                     v.push((i % 255) as u8);
                 }
                 for _ in 0..750 {
-                    v.push(random::<u8>());
+                    v.push(fastrand::u8(..));
                 }
                 for i in 0..750 {
                     v.push((i % 255) as u8);

--- a/utils/src/compression/mod.rs
+++ b/utils/src/compression/mod.rs
@@ -288,7 +288,6 @@ impl Decompressor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::prelude::random;
 
     const FORMATS: [PixelFormat; 2] = [PixelFormat::Xrgb, PixelFormat::Rgb];
 
@@ -338,7 +337,7 @@ mod tests {
                 for _ in 0..20 {
                     let mut v = Vec::with_capacity(3000);
                     for _ in 0..3000 {
-                        v.push(random::<u8>());
+                        v.push(fastrand::u8(..));
                     }
                     original.push(v);
                 }
@@ -391,13 +390,13 @@ mod tests {
                 for _ in 0..20 {
                     let mut v = Vec::with_capacity(3000);
                     for _ in 0..750 {
-                        v.push(random::<u8>());
+                        v.push(fastrand::u8(..));
                     }
                     for i in 0..750 {
                         v.push((i % 255) as u8);
                     }
                     for _ in 0..750 {
-                        v.push(random::<u8>());
+                        v.push(fastrand::u8(..));
                     }
                     for i in 0..750 {
                         v.push((i % 255) as u8);


### PR DESCRIPTION
Use criterion with `default-features=false` and `fastrand` instead of `rand` to further trim our dependencies. Both of these will mostly affect just tests builds. So their primary benefit is making the automatic cli checks run just a hinge bit faster.