### PR TITLE
better defaults for when we can't read env vars

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,6 +16,7 @@ rustix = { version = "0.38", default-features = false, features = [
   "shm",
   "mm",
   "param",
+  "process",
 ] }
 
 [build-dependencies]


### PR DESCRIPTION
Until now, if we can't read WAYLAND_DISPLAY or XDG_RUNTIME_DIR we simply panic. This commit makes it so that we try `wayland-0` and `/run/user/UID` as a default instead. We make sure to print a warning and will panic later if we can't connect.

Fixes (maybe?) #164.