### PR TITLE
Fix connecting to Wayland via WAYLAND_SOCKET

### DIFF
--- a/daemon/src/wayland/globals.rs
+++ b/daemon/src/wayland/globals.rs
@@ -211,8 +211,7 @@ fn connect() -> OwnedFd {
 
         let socket_addr =
             rustix::net::getsockname(&fd).expect("failed to get wayland socket address");
-        if let SocketAddrAny::Unix(addr) = socket_addr {
-            rustix::net::connect_unix(&fd, &addr).expect("failed to connect to unix socket");
+        if let SocketAddrAny::Unix(_) = socket_addr {
             fd
         } else {
             panic!("socket address {:?} is not a unix socket", socket_addr);


### PR DESCRIPTION
This fixes a crash when `swww-daemon` is run using a Wayland connection socket provided through the `WAYLAND_SOCKET` environment variable. (The easiest way of which I am aware to test this is to run [`waypipe`](https://gitlab.freedesktop.org/mstoeckl/waypipe/)` --oneshot ssh localhost swww-daemon`). Before this change `swww-daemon` (commit 886ce3e9c5d88187fd765fe22c92338b038177c8) would produce the error
```
thread 'main' panicked at daemon/src/wayland/globals.rs:215:51:
failed to connect to unix socket: Os { code: 111, kind: ConnectionRefused, message: "Connection refused" }
```
After this change, it should work (or possibly crash with EWouldBlock at a `super::wire::WireMsg::recv().unwrap())`, but that's a different issue I don't have time for today.)

