### PR TITLE
Fix animation cache not working when image is behind a symlink

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -150,7 +150,7 @@ fn make_img_request(
                 let animation = if !imgbuf.is_animated() {
                     None
                 } else if img.resize == ResizeStrategy::Crop {
-                    match cache::load_animation_frames(img_path, dim, pixel_format) {
+                    match cache::load_animation_frames(path.as_ref(), dim, pixel_format) {
                         Ok(Some(animation)) => Some(animation),
                         otherwise => {
                             if let Err(e) = otherwise {


### PR DESCRIPTION
I noticed that for large gifs swww takes a long time to send them to the daemon. I tried seeing if I could parallelize the process somehow but instead found that the cache just wasn't working. Fixing the cache gives a lot more performance than parallelizing the compression of the frames.

Parallelizing the compression can however be done. I did a little bit of investigating and realized that, while `pack_bytes` has to be done sequentially. Compressing `lz4` itself doesn't need to be. And after measuring the time each of those two operations take, it might be worth it.


### Rough measurments in a busy machine
```
pack_bytes_timings: Timings { 
    min: Some(1.477043ms),
    avg: 5.156188ms,
    max: 11.548624ms,
    total: 1.057301553s,
    count: 239
}
lz4_compress_timings: Timings {
    min: Some(232.441437ms),
    avg: 290.059601ms,
    max: 321.532978ms,
    total: 68.270607189s,
    count: 239
}
```