### PR TITLE
Add image filter to cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "common"
-version = "0.9.5-masterV2"
+version = "0.9.5-masterV3"
 dependencies = [
  "criterion",
  "fastrand",
@@ -837,7 +837,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "swww"
-version = "0.9.5-masterV2"
+version = "0.9.5-masterV3"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "swww-daemon"
-version = "0.9.5-masterV2"
+version = "0.9.5-masterV3"
 dependencies = [
  "common",
  "keyframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["client", "daemon", "common"]
 default-members = ["client", "daemon"]
 
 [workspace.package]
-version = "0.9.5-masterV2"
+version = "0.9.5-masterV3"
 authors = ["Leonardo Gibrowski Faé <leonardo.fae44@gmail.com>"]
 edition = "2021"
 license-file = "LICENSE"

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -83,8 +83,7 @@ impl Display for Filter {
             Self::CatmullRom => "CatmullRom",
             Self::Mitchell => "Mitchell",
             Self::Lanczos3 => "Lanczos3",
-        }
-        .to_string();
+        };
         write!(f, "{}", str)
     }
 }

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -1,6 +1,7 @@
 /// Note: this file only has basic declarations and some definitions in order to be possible to
 /// import it in the build script, to automate shell completion
 use clap::{Parser, ValueEnum};
+use std::fmt::Display;
 use std::path::PathBuf;
 
 fn from_hex(hex: &str) -> Result<[u8; 3], String> {
@@ -71,6 +72,20 @@ impl std::str::FromStr for Filter {
                      Nearest | Bilinear | CatmullRom | Mitchell | Lanczos3\
                      see swww img --help for more details"),
         }
+    }
+}
+
+impl Display for Filter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            Self::Nearest => "Nearest",
+            Self::Bilinear => "Bilinear",
+            Self::CatmullRom => "CatmullRom",
+            Self::Mitchell => "Mitchell",
+            Self::Lanczos3 => "Lanczos3",
+        }
+        .to_string();
+        write!(f, "{}", str)
     }
 }
 

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use common::cache;
 use common::ipc::{self, Answer, Client, IpcSocket, RequestSend};
 use common::mmap::Mmap;
+use image::Pixel;
 
 mod imgproc;
 use imgproc::*;
@@ -119,9 +120,13 @@ fn make_img_request(
             for (&dim, outputs) in dims.iter().zip(outputs) {
                 img_req_builder.push(
                     ipc::ImgSend {
-                        img: image::RgbImage::from_pixel(dim.0, dim.1, image::Rgb(*color))
-                            .to_vec()
-                            .into_boxed_slice(),
+                        img: image::RgbaImage::from_pixel(
+                            dim.0,
+                            dim.1,
+                            image::Rgb(*color).to_rgba(),
+                        )
+                        .to_vec()
+                        .into_boxed_slice(),
                         path: format!("0x{:02x}{:02x}{:02x}", color[0], color[1], color[2]),
                         dim,
                         format: pixel_format,

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -82,10 +82,12 @@ pub fn get_previous_image_path(output_name: &str) -> io::Result<(String, String)
         )
     })?;
 
-    if let Some(buf) = buf.split_once("\n") {
-        Ok((buf.0.to_string(), buf.1.to_string()))
-    } else {
-        Ok(("Lanczos3".to_string(), buf))
+    match buf.split_once("\n") {
+        Some(buf) => Ok((buf.0.to_string(), buf.1.to_string())),
+        None => Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "failed to read image filter",
+        )),
     }
 }
 

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -14,10 +14,10 @@ use crate::ipc::Animation;
 use crate::ipc::PixelFormat;
 use crate::mmap::Mmap;
 
-pub(crate) fn store(output_name: &str, img_path: &str) -> io::Result<()> {
+pub(crate) fn store(output_name: &str, img_path: &str, filter: &str) -> io::Result<()> {
     let mut filepath = cache_dir()?;
     filepath.push(output_name);
-    File::create(filepath)?.write_all(img_path.as_bytes())
+    File::create(filepath)?.write_all(format!("{filter}\n{img_path}").as_bytes())
 }
 
 pub(crate) fn store_animation_frames(
@@ -64,28 +64,33 @@ pub fn load_animation_frames(
     Ok(None)
 }
 
-pub fn get_previous_image_path(output_name: &str) -> io::Result<String> {
+pub fn get_previous_image_path(output_name: &str) -> io::Result<(String, String)> {
     let mut filepath = cache_dir()?;
     clean_previous_verions(&filepath);
 
     filepath.push(output_name);
     if !filepath.is_file() {
-        return Ok("".to_string());
+        return Ok(("Lanczos3".to_string(), "".to_string()));
     }
 
     let mut buf = Vec::with_capacity(64);
     File::open(filepath)?.read_to_end(&mut buf)?;
-
-    String::from_utf8(buf).map_err(|e| {
+    let buf = String::from_utf8(buf).map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::Other,
             format!("failed to decode bytes: {e}"),
         )
-    })
+    })?;
+
+    if let Some(buf) = buf.split_once("\n") {
+        Ok((buf.0.to_string(), buf.1.to_string()))
+    } else {
+        Ok(("Lanczos3".to_string(), buf))
+    }
 }
 
 pub fn load(output_name: &str) -> io::Result<()> {
-    let img_path = get_previous_image_path(output_name)?;
+    let (filter, img_path) = get_previous_image_path(output_name)?;
     if img_path.is_empty() {
         return Ok(());
     }
@@ -105,6 +110,7 @@ pub fn load(output_name: &str) -> io::Result<()> {
         .arg("img")
         .args([
             &format!("--outputs={output_name}"),
+            &format!("--filter={filter}"),
             "--transition-type=none",
             &img_path,
         ])

--- a/common/src/cache.rs
+++ b/common/src/cache.rs
@@ -70,7 +70,7 @@ pub fn get_previous_image_path(output_name: &str) -> io::Result<(String, String)
 
     filepath.push(output_name);
     if !filepath.is_file() {
-        return Ok(("Lanczos3".to_string(), "".to_string()));
+        return Ok(("".to_string(), "".to_string()));
     }
 
     let mut buf = Vec::with_capacity(64);

--- a/common/src/ipc/mod.rs
+++ b/common/src/ipc/mod.rs
@@ -59,7 +59,13 @@ impl ImageRequestBuilder {
     }
 
     #[inline]
-    pub fn push(&mut self, img: ImgSend, outputs: &[String], animation: Option<Animation>) {
+    pub fn push(
+        &mut self,
+        img: ImgSend,
+        filter: String,
+        outputs: &[String],
+        animation: Option<Animation>,
+    ) {
         self.img_count += 1;
 
         let ImgSend {
@@ -89,7 +95,7 @@ impl ImageRequestBuilder {
 
         // cache the request
         for output in outputs.iter() {
-            if let Err(e) = super::cache::store(output, path) {
+            if let Err(e) = super::cache::store(output, path, &filter) {
                 eprintln!("ERROR: failed to store cache: {e}");
             }
         }


### PR DESCRIPTION
I primary use pixel art wallpapers, so the default filter for all restored images was annoying.
I modified cache so it stores filter and path to image separated by '\n' (I couldn't think of anything better). It can work with old version of cache if it doesn't contain '\n' using default filter.
I also fixed a crash that occurred when using a solid color on my system (EndevourOS + Hyprland): the drawable surface required RGBA image but was only provided with RGB.
I'm still learning Rust and English is not my native language, so sorry if anything is wrong.