### PR TITLE
Add stretch to resize options

### DIFF
--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -212,7 +212,7 @@ pub enum ResizeStrategy {
     Crop,
     /// Resize the image to fit inside the screen, preserving the original aspect ratio
     Fit,
-    /// Resize the image to stretch across the screen
+    /// Resize the image to fit inside the screen, without preserving the original aspect ratio
     Stretch,
 }
 

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -212,6 +212,8 @@ pub enum ResizeStrategy {
     Crop,
     /// Resize the image to fit inside the screen, preserving the original aspect ratio
     Fit,
+    /// Resize the image to stretch across the screen
+    Stretch,
 }
 
 #[derive(Parser)]

--- a/client/src/imgproc.rs
+++ b/client/src/imgproc.rs
@@ -218,7 +218,7 @@ pub fn compress_frames(
             ResizeStrategy::No => img_pad(&img, dim, color)?,
             ResizeStrategy::Crop => img_resize_crop(&img, dim, filter)?,
             ResizeStrategy::Fit => img_resize_fit(&img, dim, filter, color)?,
-            ResizeStrategy::Stretch => img_resize_crop(&img, dim, filter)?,
+            ResizeStrategy::Stretch => img_resize_stretch(&img, dim, filter)?,
         };
 
         if let Some(canvas) = canvas.as_ref() {
@@ -409,8 +409,7 @@ pub fn img_resize_stretch(
 
         let mut dst = fast_image_resize::images::Image::new(width, height, pixel_type);
         let mut resizer = Resizer::new();
-        let options = ResizeOptions::new()
-            .resize_alg(ResizeAlg::Convolution(filter));
+        let options = ResizeOptions::new().resize_alg(ResizeAlg::Convolution(filter));
 
         if let Err(e) = resizer.resize(&src, &mut dst, Some(&options)) {
             return Err(e.to_string());

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -184,6 +184,9 @@ fn make_img_request(
                     ResizeStrategy::Fit => {
                         img_resize_fit(&img_raw, dim, make_filter(&img.filter), &img.fill_color)?
                     }
+                    ResizeStrategy::Stretch => {
+                        img_resize_stretch(&img_raw, dim, make_filter(&img.filter))?
+                    }
                 };
 
                 img_req_builder.push(

--- a/doc/swww-img.1.scd
+++ b/doc/swww-img.1.scd
@@ -40,9 +40,10 @@ swww-img
 	Whether to resize the image and the method by which to resize it.
 
 	Possible values:
-		- _no_:   Do not resize the image
-		- _crop_: Resize the image to fill the whole screen, cropping out parts that don't fit
-		- _fit_:  Resize the image to fit inside the screen, preserving the original aspect ratio
+		- _no_:       Do not resize the image
+		- _crop_:     Resize the image to fill the whole screen, cropping out parts that don't fit
+		- _fit_:      Resize the image to fit inside the screen, preserving the original aspect ratio
+		- _stretch_:  Resize the image to fit inside the screen, without preserving the original aspect ratio
 
 	Default is _crop_.
 


### PR DESCRIPTION
I added stretch to the --resize options. The function is almost identical to the crop function with just a minor change. I have tested it locally and it seems to be working correctly.

Something similar to this was mentioned in issue #166 