### PR TITLE
Fix memory leak and stopped animation when connecting/disconnecting monitor

### DIFF
--- a/common/src/ipc/types.rs
+++ b/common/src/ipc/types.rs
@@ -86,6 +86,10 @@ impl BgImg {
             Self::Img(s) => 4 + s.len()
         }
     }
+
+    pub fn is_set(&self) -> bool {
+        matches!(self, Self::Img(_))
+    }
 }
 
 impl fmt::Display for BgImg {
@@ -147,7 +151,7 @@ impl PixelFormat {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug)]
 pub enum Scale {
     Whole(NonZeroI32),
     Fractional(NonZeroI32),
@@ -180,6 +184,18 @@ impl Scale {
                 (width, height)
             }
         }
+    }
+}
+
+impl PartialEq for Scale {
+    fn eq(&self, other: &Self) -> bool {
+        (match self {
+            Self::Whole(i) => i.get() * 120,
+            Self::Fractional(f) => f.get(),
+        }) == (match other {
+            Self::Whole(i) => i.get() * 120,
+            Self::Fractional(f) => f.get(),
+        })
     }
 }
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -372,9 +372,12 @@ impl wayland::interfaces::wl_output::EvHandler for Daemon {
     fn done(&mut self, sender_id: ObjectId) {
         for wallpaper in self.wallpapers.iter() {
             if wallpaper.borrow().has_output(sender_id) {
-                wallpaper
+                if wallpaper
                     .borrow_mut()
-                    .commit_surface_changes(self.use_cache);
+                    .commit_surface_changes(self.use_cache)
+                {
+                    self.stop_animations(&[wallpaper.clone()]);
+                }
                 break;
             }
         }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -375,7 +375,6 @@ impl wayland::interfaces::wl_output::EvHandler for Daemon {
                 wallpaper
                     .borrow_mut()
                     .commit_surface_changes(self.use_cache);
-                self.stop_animations(&[wallpaper.clone()]);
                 break;
             }
         }
@@ -480,8 +479,14 @@ impl wayland::interfaces::zwlr_layer_surface_v1::EvHandler for Daemon {
     }
 
     fn closed(&mut self, sender_id: ObjectId) {
-        self.wallpapers
-            .retain(|w| !w.borrow().has_layer_surface(sender_id));
+        if let Some(i) = self
+            .wallpapers
+            .iter()
+            .position(|w| w.borrow().has_layer_surface(sender_id))
+        {
+            let w = self.wallpapers.remove(i);
+            self.stop_animations(&[w]);
+        }
     }
 }
 

--- a/daemon/src/wallpaper.rs
+++ b/daemon/src/wallpaper.rs
@@ -182,8 +182,7 @@ impl Wallpaper {
 
     pub fn set_scale(&mut self, scale: Scale) {
         let staging = &mut self.inner_staging;
-        if matches!(staging.scale_factor, Scale::Fractional(_)) && matches!(scale, Scale::Whole(_))
-        {
+        if staging.scale_factor == scale {
             return;
         }
 
@@ -219,7 +218,12 @@ impl Wallpaper {
         let inner = &mut self.inner;
         let staging = &self.inner_staging;
 
-        if inner.name != staging.name && use_cache {
+        if (inner.name != staging.name && use_cache)
+            || (self.img.is_set()
+                && (inner.scale_factor != staging.scale_factor
+                    || inner.width != staging.width
+                    || inner.height != staging.height))
+        {
             let name = staging.name.clone().unwrap_or("".to_string());
             std::thread::Builder::new()
                 .name("cache loader".to_string())


### PR DESCRIPTION
1. Memory leak when connecting/disconnecting monitor (happens on KDE Plasma and Hyprland): if I understand it correctly, Compositor sends LayerSurface closed event which removes Wallpaper belonging to closed surface from Daemon.wallpapers, later Compositor sends WL_REGISTRY global_remove which tries to delete Wallpaper belonging to closed output and stop it animation by searching Daemon.wallpapers by output_name, but fails because Wallpaper has already been removed. This leads to not deleted TransitionAnimator and ImageAnimator, which stops Wallpaper from being dropped and starts memory leak in buffer leading to swww-daemon termination.
Because I don't know right way to handle this I just duplicated code from global_remove event to closed event so both now stop animations.
2. Stop of animation on primary monitor when connecting/disconnecting second one (only on Hyprland): when disconnecting second, monitor Hyprland sends wl_output done event for primary monitor, and when connecting second monitor Hyprland sends sequence of events with done event in the end for both monitors. wl_output done event stops animations so connecting/disconnecting second monitor stops wallpaper animation on first one.
I don't know right way to handle this either so I just removed stop_animations from wl_output done event.