### PR TITLE
fix vertical monitor transitions & 'failed to load cache' errors

### DIFF
--- a/daemon/src/wallpaper.rs
+++ b/daemon/src/wallpaper.rs
@@ -252,13 +252,7 @@ impl Wallpaper {
         use wl_output::transform;
         let inner = &mut self.inner;
         let staging = &self.inner_staging;
-
-        if (inner.name != staging.name && use_cache)
-            || (self.img.is_set()
-                && (inner.scale_factor != staging.scale_factor
-                    || inner.width != staging.width
-                    || inner.height != staging.height))
-        {
+        if inner.name != staging.name && use_cache {
             let name = staging.name.clone().unwrap_or("".to_string());
             std::thread::Builder::new()
                 .name("cache loader".to_string())


### PR DESCRIPTION
Fixed Issues: 
 - Transitions on vertical monitor's were having issues
 - `[WARN]  failed to load cache: there is already another swww process running` errors on wallpaper changes
 
 Discussion: [Wallpaper changing animations do not work on vertical monitor
](https://github.com/LGFae/swww/issues/386)

have not written rust, 
I am not sure if this causes issues with https://github.com/LGFae/swww/commit/56928f7c0e55a321ad5a83a039e0e0dc3eeac35b 

