### PR TITLE
Make example scripts more portable

### DIFF
--- a/example_scripts/swww_randomize.sh
+++ b/example_scripts/swww_randomize.sh
@@ -1,32 +1,28 @@
-#!/bin/bash
+#!/bin/sh
+# Changes the wallpaper to a randomly chosen image in a given directory
+# at a set interval.
 
-# This script will randomly go through the files of a directory, setting it
-# up as the wallpaper at regular intervals
-#
-# NOTE: this script is in bash (not posix shell), because the RANDOM variable
-# we use is not defined in posix
+DEFAULT_INTERVAL=300 # In seconds
 
-if [[ $# -lt 1 ]] || [[ ! -d $1   ]]; then
-	echo "Usage:
-	$0 <dir containing images>"
+if [ $# -lt 1 ] || [ ! -d "$1" ]; then
+	printf "Usage:\n\t\e[1m%s\e[0m \e[4mDIRECTORY\e[0m [\e[4mINTERVAL\e[0m]\n" "$0"
+	printf "\tChanges the wallpaper to a randomly chosen image in DIRECTORY every\n\tINTERVAL seconds (or every %d seconds if unspecified)." "$DEFAULT_INTERVAL"
 	exit 1
 fi
 
-# Edit below to control the images transition
-export SWWW_TRANSITION_FPS=60
-export SWWW_TRANSITION_STEP=2
-
-# This controls (in seconds) when to switch to the next image
-INTERVAL=300
+# See swww-img(1)
+RESIZE_TYPE="fit"
+export SWWW_TRANSITION_FPS="${SWWW_TRANSITION_FPS:-60}"
+export SWWW_TRANSITION_STEP="${SWWW_TRANSITION_STEP:-2}"
 
 while true; do
 	find "$1" -type f \
-		| while read -r img; do
-			echo "$((RANDOM % 1000)):$img"
-		done \
-		| sort -n | cut -d':' -f2- \
-		| while read -r img; do
-			swww img "$img"
-			sleep $INTERVAL
-		done
+	| while read -r img; do
+		echo "$(</dev/urandom tr -dc a-zA-Z0-9 | head -c 8):$img"
+	done \
+	| sort -n | cut -d':' -f2- \
+	| while read -r img; do
+		swww img --resize="$RESIZE_TYPE" "$img"
+		sleep "${2:-$DEFAULT_INTERVAL}"
+	done
 done

--- a/example_scripts/swww_randomize_multi.sh
+++ b/example_scripts/swww_randomize_multi.sh
@@ -27,7 +27,7 @@ while true; do
 			# and pick again if no more unused images are remaining
 			[ -z "$img" ] && read -r img || break 2
 			swww img --resize "$RESIZE_TYPE" --outputs "$d" "$img"
-			unset -v $img
+			unset -v $img # Each image should only be used once per loop
 		done
 		sleep "${2:-$DEFAULT_INTERVAL}"
 	done

--- a/example_scripts/swww_randomize_multi.sh
+++ b/example_scripts/swww_randomize_multi.sh
@@ -1,73 +1,34 @@
-#!/bin/bash
+#!/bin/sh
+# For each display, changes the wallpaper to a randomly chosen image in
+# a given directory at a set interval.
 
-# This script will randomly go through the files of a directory,
-# setting a different random wallpaper for each display
-# at regular intervals
-#
-# NOTE: this script is in bash (not posix shell), because the RANDOM variable
-# we use is not defined in posix
+DEFAULT_INTERVAL=300 # In seconds
 
-if [[ $# -lt 1 ]] || [[ ! -d $1 ]]; then
-    echo "Usage:
-    $0 <dir containing images>"
-    exit 1
+if [ $# -lt 1 ] || [ ! -d "$1" ]; then
+	printf "Usage:\n\t\e[1m%s\e[0m \e[4mDIRECTORY\e[0m [\e[4mINTERVAL\e[0m]\n" "$0"
+	printf "\tChanges the wallpaper to a randomly chosen image in DIRECTORY every\n\tINTERVAL seconds (or every %d seconds if unspecified)." "$DEFAULT_INTERVAL"
+	exit 1
 fi
 
-# Make sure only 1 instance of swww_randomize
-PIDFILE=~/.local/state/swww-randomize-pidfile.txt
-if [ -e "${PIDFILE}" ]; then
-    OLD_PID="$(<${PIDFILE})"
-    if [ "X" != "X${OLD_PID}" -a -e "/proc/${OLD_PID}" ]; then
-        OLD_NAME="$(</proc/${OLD_PID}/comm)"
-        THIS_NAME="$(</proc/${BASHPID}/comm)"
-        if [ "${OLD_NAME}" = "${THIS_NAME}" ]; then
-            echo "old randomize process ${OLD_PID} is still running"
-            exit 1
-        else
-            echo "process with same ID as old randomize is running: \"${OLD_NAME}\"@${OLD_PID}"
-            echo "Replacing old process ID"
-        fi
-    fi
-fi
-echo "${BASHPID}" > ${PIDFILE}
-
-# Edit below to control the images transition
-export SWWW_TRANSITION_FPS=60
-export SWWW_TRANSITION_STEP=2
-
-# This controls (in seconds) when to switch to the next image
-INTERVAL=300
-
-# Possible values:
-#    -   no:   Do not resize the image
-#    -   crop: Resize the image to fill the whole screen, cropping out parts that don't fit
-#    -   fit:  Resize the image to fit inside the screen, preserving the original aspect ratio
+# See swww-img(1)
 RESIZE_TYPE="fit"
-
-DISPLAY_LIST=$(swww query | grep -Po "^[^:]+")
+export SWWW_TRANSITION_FPS="${SWWW_TRANSITION_FPS:-60}"
+export SWWW_TRANSITION_STEP="${SWWW_TRANSITION_STEP:-2}"
 
 while true; do
-    find "$1" -type f \
-        | while read -r img; do
-            echo "$RANDOM:$img"
-        done \
-        | sort -n | cut -d':' -f2- \
-        | tee ~/.local/state/swww-randomize-list.txt \
-        | while read -r img; do
-            # Set a different image for each display
-            for disp in $DISPLAY_LIST; do
-                # if there is no image try to get one
-                if [ "X" = "X${img}" ]; then
-                    if read -r img; then
-                        true
-                    else # if there are no more images, refresh the list
-                        break 2
-                    fi
-                fi
-                swww img --resize=$RESIZE_TYPE --outputs $disp $img
-                # make sure each image is only used once
-                img=""
-            done
-            sleep $INTERVAL
-        done
+	find "$1" -type f \
+	| while read -r img; do
+		echo "$(</dev/urandom tr -dc a-zA-Z0-9 | head -c 8):$img"
+	done \
+	| sort -n | cut -d':' -f2- \
+	| while read -r img; do
+		for d in $(swww query | grep -Po "^[^:]+"); do # see swww-query(1)
+			# Get next random image for this display, or re-shuffle images
+			# and pick again if no more unused images are remaining
+			[ -z "$img" ] && read -r img || break 2
+			swww img --resize "$RESIZE_TYPE" --outputs "$d" "$img"
+			unset -v $img
+		done
+		sleep "${2:-$DEFAULT_INTERVAL}"
+	done
 done

--- a/example_scripts/swww_randomize_multi.sh
+++ b/example_scripts/swww_randomize_multi.sh
@@ -25,9 +25,9 @@ while true; do
 		for d in $(swww query | grep -Po "^[^:]+"); do # see swww-query(1)
 			# Get next random image for this display, or re-shuffle images
 			# and pick again if no more unused images are remaining
-			[ -z "$img" ] && read -r img || break 2
+			[ -z "$img" ] && if read -r img; then true; else break 2; fi
 			swww img --resize "$RESIZE_TYPE" --outputs "$d" "$img"
-			unset -v $img # Each image should only be used once per loop
+			unset -v img # Each image should only be used once per loop
 		done
 		sleep "${2:-$DEFAULT_INTERVAL}"
 	done


### PR DESCRIPTION
This is an attempt to make `swww_randomize.sh` and `swww_randomize_multi.sh` more portable by replacing the `$RANDOM` `bash`-ism with more portable way of randomizing the files.

This also removes `swww_randomize_multi.sh`'s check to make sure it is not already running, since it uses `$BASHPID`. In my subjective opinion, such logic is not needed in the first place, since these scripts are likely to be run once by the compositor automatically rather than manually invoked multiple times. That said, if it is required, I will write a portable solution that doesn't use `$BASHPID` and apply that solution in `swww_randomize.sh` as well, which currently lacks this check.