### PR TITLE
fix incorrect description of swww clear-cache in swww(1) man page

### DIFF
--- a/doc/swww.1.scd
+++ b/doc/swww.1.scd
@@ -15,7 +15,7 @@ swww - A Solution to your Wayland Wallpaper Woes
 	Restores the last displayed image on the specified outputs
 
 *clear-cache*
-	Fills the specified outputs with the given color
+	Deletes the `swww` cache directory
 
 *img*
 	Sends an image (or animated gif) for the daemon to display


### PR DESCRIPTION
Current description of swww clear-cache in swww(1) manual page is the duplicate of swww clear, which doesn't explain the actual function of clear-cache command. Changed it to correct description based on text in swww-clear-cache(1) manual page.