### PR TITLE
fix animations with 4 channels

### DIFF
--- a/common/src/compression/decomp/mod.rs
+++ b/common/src/compression/decomp/mod.rs
@@ -52,7 +52,8 @@ pub(super) fn unpack_bytes_4channels(buf: &mut [u8], diff: &[u8]) {
         );
         for _ in 0..to_cpy {
             unsafe {
-                std::ptr::copy_nonoverlapping(diff_ptr.add(diff_idx), buf_ptr.add(pix_idx * 4), 4)
+                std::ptr::copy_nonoverlapping(diff_ptr.add(diff_idx), buf_ptr.add(pix_idx * 4), 4);
+                buf_ptr.add(pix_idx * 4 + 3).write(255);
             }
             diff_idx += 3;
             pix_idx += 1;


### PR DESCRIPTION
Previously, we were using the xrgb shm format, which ignores alpha values. Because of this, during animations, we could afford to write garbage every 4th byte, because it would be ignored by the compositor. Now that we are using the argb shm format, we have to fill up the alpha channel properly.

Fixed #479 .