### PR TITLE
Adjust multi monitor example script

### DIFF
--- a/example_scripts/swww_randomize_multi.sh
+++ b/example_scripts/swww_randomize_multi.sh
@@ -22,7 +22,7 @@ while true; do
 	done \
 	| sort -n | cut -d':' -f2- \
 	| while read -r img; do
-		for d in $(swww query | grep -Po "^[^:]+"); do # see swww-query(1)
+		for d in $(swww query | awk '{print $2}' | sed s/://); do # see swww-query(1)
 			# Get next random image for this display, or re-shuffle images
 			# and pick again if no more unused images are remaining
 			[ -z "$img" ] && if read -r img; then true; else break 2; fi


### PR DESCRIPTION
Since 0.11.0 the format for `swww query` changed to display the namespace in the first column instead of the output.
This breaks the multi monitor script which depends on `swww query` to get the different outputs.
This PR should fix this issue.

I used `awk` and `sed` instead of `grep`, since the regex would have gotten significantly more complex than previously, and this seems more straightforward for me.